### PR TITLE
Temp workaround for Pull to Refresh issue in ReferringSites Collection View

### DIFF
--- a/GitTrends/ViewModels/ReferringSitesViewModel.cs
+++ b/GitTrends/ViewModels/ReferringSitesViewModel.cs
@@ -63,7 +63,10 @@ namespace GitTrends
                 }
 
                 foreach (var site in referringSitesList.OrderByDescending(x => x.TotalCount))
+                {
                     ReferringSitesCollection.Add(site);
+                    await Task.Delay(500);
+                }
             }
             finally
             {


### PR DESCRIPTION
Added Task.Delay when adding items to our CollectionView, lowest I could set it was 500 ms so it didn't trigger the exception.

Temp workaround for issue #24 