### PR TITLE
Added editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,105 @@
+﻿# Suppress: EC112
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+
+# Code files
+[*.sln]
+indent_size = 4
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# XML files
+[*.xml]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_require_accessibility_modifiers = omit_if_default:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# Naming Conventions:
+# Pascal Casing
+dotnet_naming_symbols.method_and_property_symbols.applicable_kinds= method,property,enum
+dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities = *
+dotnet_naming_style.pascal_case_style.capitalization =   pascal_case
+
+dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity = warning
+dotnet_naming_rule.methods_and_properties_must_be_pascal_case.symbols = method_and_property_symbols
+dotnet_naming_rule.methods_and_properties_must_be_pascal_case.style = pascal_case_style
+
+# Non-public members must be lower-case
+dotnet_naming_symbols.non_public_symbols.applicable_kinds = field
+dotnet_naming_symbols.non_public_symbols.applicable_accessibilities = private
+#dotnet_naming_style.all_lower_case_style.capitalization = camel_case
+
+dotnet_naming_rule.non_public_members_must_be_lower_case.severity = warning
+dotnet_naming_rule.non_public_members_must_be_lower_case.symbols = non_public_symbols
+dotnet_naming_rule.non_public_members_must_be_lower_case.style = all_lower_case_style
+
+# CSharp code style settings:
+[*.cs]
+# Do not prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = true:none
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = true:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true

--- a/GitTrends.Mobile.Shared/Constants/PageTitles.cs
+++ b/GitTrends.Mobile.Shared/Constants/PageTitles.cs
@@ -2,7 +2,7 @@
 {
     public static class PageTitles
     {
-		public const string RepositoryPage = "Repositories";
+        public const string RepositoryPage = "Repositories";
         public const string SettingsPage = "Settings";
         public const string ReferringSitesPage = "Referring Sites";
     }

--- a/GitTrends.sln
+++ b/GitTrends.sln
@@ -22,6 +22,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitTrends.UITests", "GitTre
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitTrends.Functions", "GitTrends.Functions\GitTrends.Functions.csproj", "{09224C6B-D0E4-4CC8-9CCB-936D6A22D57B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{277A4FFB-91D3-4028-A47C-C39726594FC1}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		GitTrends.Mobile.Shared\GitTrends.Mobile.Shared.projitems*{16224020-a5fb-41cb-ad1d-a411b4c7b75b}*SharedItemsImports = 13


### PR DESCRIPTION
Hi Brandon,
I have added editorconfig to the solution.

I have started from the editorconfig in Xamarin Essentials, then I didn't want your code to explode, so I've changed a few settings:
- removed rule to use var for simple variables;
- removed rule for casing of internal variables.
- (I have kept the suggestion to inline simple method definitions, but they don't generate any warnings).

I also I have changed one file, that had one line of tabs instead of spaces.