### PR TITLE
Polishments and Fix for Onboarding Launch Issue in Android 

### DIFF
--- a/GitTrends.Android/Properties/AndroidManifest.xml
+++ b/GitTrends.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="18" android:versionName="1.0.0" package="com.minnick.gittrends" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
-	<application android:label="GitTrends" android:fullBackupContent="@xml/auto_backup_rules" />
+	<application android:label="GitTrends" android:allowBackup="false" />
 </manifest>

--- a/GitTrends/Pages/Onboarding/BaseOnboardingContentPage.cs
+++ b/GitTrends/Pages/Onboarding/BaseOnboardingContentPage.cs
@@ -34,7 +34,7 @@ namespace GitTrends
                 RowDefinitions = Rows.Define(
                     (Row.Image, StarGridLength(Device.RuntimePlatform is Device.iOS ? 3 : 11)),
                     (Row.Description, StarGridLength(Device.RuntimePlatform is Device.iOS ? 2 : 9)),
-                    (Row.Indicator, AbsoluteGridLength(44))),
+                    (Row.Indicator, AbsoluteGridLength(48))),
 
                 ColumnDefinitions = Columns.Define(
                     (Column.Indicator, StarGridLength(1)),
@@ -68,11 +68,12 @@ namespace GitTrends
                 TextColor = Color.White;
                 BackgroundColor = Color.Transparent;
                 FontFamily = FontFamilyConstants.RobotoBold;
+                FontSize = 14;
 
                 Margin = new Thickness(0, 0, 30, 0);
 
                 HorizontalOptions = LayoutOptions.End;
-                VerticalOptions = LayoutOptions.Center;
+                VerticalOptions = LayoutOptions.FillAndExpand;
 
                 AutomationId = OnboardingAutomationIds.NextButon;
 
@@ -131,8 +132,10 @@ namespace GitTrends
                 Position = position;
                 SelectedIndicatorColor = Color.White;
                 IndicatorColor = Color.White.MultiplyAlpha(0.25);
-                Margin = new Thickness(30, 0, 0, 0);
+                Margin = new Thickness(30, 4, 0, 0);
                 HorizontalOptions = LayoutOptions.Start;
+                VerticalOptions = LayoutOptions.Start;
+                IndicatorSize = 12;
                 AutomationId = OnboardingAutomationIds.PageIndicator;
 
                 SetBinding(CountProperty, new Binding(nameof(OnboardingCarouselPage.PageCount),

--- a/GitTrends/Views/ReferringSites/ReferringSitesDataTemplate.cs
+++ b/GitTrends/Views/ReferringSites/ReferringSitesDataTemplate.cs
@@ -80,7 +80,7 @@ namespace GitTrends
                         (Column.Referrals, StarGridLength(1.5)),
                         (Column.ReferralPadding, AbsoluteGridLength(4)),
                         (Column.Separator, AbsoluteGridLength(1)),
-                        (Column.UniquePadding, AbsoluteGridLength(4)),
+                        (Column.UniquePadding, AbsoluteGridLength(6)),
                         (Column.Uniques, StarGridLength(1)));
 
                     Children.Add(new FavIconImage()


### PR DESCRIPTION

- Polishment in spacings of ReferringSitesDataTemplate
The space between Referrals and Unique separators were not even as shown in the following screenshots.

**Before (notice how unique is a bit closer):**

![Screenshot_20200414-022152](https://user-images.githubusercontent.com/16939480/79226578-a2032f80-7e2c-11ea-9ec4-7c56cd13f852.png)

**After:**
![Screenshot_20200414-022108](https://user-images.githubusercontent.com/16939480/79226641-b515ff80-7e2c-11ea-8b11-9394bf93cbe7.png)

- Polishment of indicator and next label on the onboarding page.
There was not enough space for the indicator and the next/demo button between the bottom system bar so the user could access it easily while tapping and not miss press the system bar, added the recommended 32 spacing.

**Before:**
![Screenshot_20200414-031542](https://user-images.githubusercontent.com/16939480/79227201-89474980-7e2d-11ea-91cb-18d12aeca342.png)

![Screenshot_20200414-031554](https://user-images.githubusercontent.com/16939480/79227216-8cdad080-7e2d-11ea-8292-6beadc9d272f.png)

**After:**
![Screenshot_20200414-031952](https://user-images.githubusercontent.com/16939480/79227234-95330b80-7e2d-11ea-9567-352db9218f24.png)

![Screenshot_20200414-031957](https://user-images.githubusercontent.com/16939480/79227243-982dfc00-7e2d-11ea-9ff0-faf946ed0a77.png)

## [ISSUES SOLVED]
Android App was backing up shared preferences to the cloud and the app wouldn't behave as expected on a fresh install, in regards to onboarding since it was being persisted in the user drive account. more related about this here: https://www.pujolsluis.com/android-auto-backup-and-why-we-need-to-manage-it-properly-in-xamarin/
- Disable Auto-backup in the android project, to fix onboarding not showing up on reinstall.
