### PR TITLE
Git ignore entry for MFractor meta-data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -663,6 +663,8 @@ sysinfo.txt
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# MFractor
+.mfractor/
 
 ### VisualStudio ###
 ## Ignore Visual Studio temporary files, build results, and


### PR DESCRIPTION
Hey Brandon, was browsing the apps source code and noticed that MFractors meta-data directory was commited (possibly from a PR).

This change will exclude it from future commits.