### PR TITLE
Move App Center API Keys to Azure

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -53,6 +53,7 @@ jobs:
       runs-on: macos-latest
       env:
         GetTestTokenApiKey: ${{ secrets.GetTestTokenApiKey }}
+        GetAppCenterApiKeysKey: ${{ secrets.GetAppCenterApiKeysKey}}
         GetSyncFusionInformationApiKey: ${{ secrets.GetSyncFusionInformationApiKey }}
         GetNotificationHubInformationApiKey: ${{ secrets.GetNotificationHubInformationApiKey }}
         APPCENTER_SOURCE_DIRECTORY: .

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -14,6 +14,7 @@ jobs:
       runs-on: macos-latest
       env:
         GetTestTokenApiKey: ${{ secrets.GetTestTokenApiKey }}
+        GetAppCenterApiKeysKey: ${{ secrets.GetAppCenterApiKeysKey}}
         GetSyncFusionInformationApiKey: ${{ secrets.GetSyncFusionInformationApiKey }}
         GetNotificationHubInformationApiKey: ${{ secrets.GetNotificationHubInformationApiKey }}
         APPCENTER_SOURCE_DIRECTORY: .

--- a/GitTrends.Android/appcenter-pre-build.sh
+++ b/GitTrends.Android/appcenter-pre-build.sh
@@ -2,7 +2,7 @@
 set -e
 
 AzureConstantsFile=`find "$APPCENTER_SOURCE_DIRECTORY" -name AzureConstants.cs | head -1`
-echo CognitiveServicesConstantsFile = $AzureConstantsFile
+echo AzureConstantsFile = $AzureConstantsFile
 
 echo "Injecting API Keys"
 

--- a/GitTrends.Android/appcenter-pre-build.sh
+++ b/GitTrends.Android/appcenter-pre-build.sh
@@ -8,6 +8,8 @@ echo "Injecting API Keys"
 
 sed -i '' "s/GetTestTokenApiKey = \"\"/GetTestTokenApiKey = \"$GetTestTokenApiKey\"/g" "$AzureConstantsFile"
 
+sed -i '' "s/GetAppCenterApiKeysKey = \"\"/GetAppCenterApiKeysKey = \"$GetAppCenterApiKeysKey\"/g" "$AzureConstantsFile"
+
 sed -i '' "s/GetSyncFusionInformationApiKey = \"\"/GetSyncFusionInformationApiKey = \"$GetSyncFusionInformationApiKey\"/g" "$AzureConstantsFile"
 
 sed -i '' "s/GetNotificationHubInformationApiKey = \"\"/GetNotificationHubInformationApiKey = \"$GetNotificationHubInformationApiKey\"/g" "$AzureConstantsFile"

--- a/GitTrends.Functions/Functions/GetAppCenterApiKeys.cs
+++ b/GitTrends.Functions/Functions/GetAppCenterApiKeys.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using GitTrends.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace GitTrends.Functions
+{
+    public static class GetAppCenterApiKeys
+    {
+        readonly static string _iOS = Environment.GetEnvironmentVariable("AppCenterApiKey_iOS") ?? string.Empty;
+        readonly static string _android = Environment.GetEnvironmentVariable("AppCenterApiKey_Android") ?? string.Empty;
+
+        [FunctionName(nameof(GetAppCenterApiKeys))]
+        public static IActionResult Run([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest request, ILogger log)
+        {
+            log.LogInformation("Retrieving Client Id");
+
+            if (string.IsNullOrWhiteSpace(_iOS))
+                return new NotFoundObjectResult($"{nameof(_iOS)} Not Found");
+
+            if (string.IsNullOrWhiteSpace(_android))
+                return new NotFoundObjectResult($"{nameof(_android)} Not Found");
+
+            return new OkObjectResult(new AppCenterApiKeyDTO(_iOS, _android));
+        }
+    }
+}

--- a/GitTrends.Functions/Functions/GetTestToken.cs
+++ b/GitTrends.Functions/Functions/GetTestToken.cs
@@ -21,7 +21,6 @@ namespace GitTrends.Functions
         readonly static IReadOnlyList<string> _testTokenList = new[]
         {
             Environment.GetEnvironmentVariable("UITestToken_brminnick") ?? string.Empty,
-            Environment.GetEnvironmentVariable("UITestToken_GitTrends") ?? string.Empty,
             Environment.GetEnvironmentVariable("UITestToken_GitTrendsApp") ?? string.Empty,
             Environment.GetEnvironmentVariable("UITestToken_TheCodeTraveler") ?? string.Empty
         };

--- a/GitTrends.Functions/GitTrends.Functions.csproj
+++ b/GitTrends.Functions/GitTrends.Functions.csproj
@@ -7,10 +7,10 @@
         <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' ">
-      <IntermediateOutputPath>obj\AppStore</IntermediateOutputPath>
+      <IntermediateOutputPath>obj\AppStore\netcoreapp3.1</IntermediateOutputPath>
       <DebugType></DebugType>
       <Optimize>false</Optimize>
-      <OutputPath>bin\AppStore</OutputPath>
+      <OutputPath>bin\AppStore\netcoreapp3.1</OutputPath>
       <DefineConstants></DefineConstants>
       <NoWarn></NoWarn>
       <LangVersion>Default</LangVersion>

--- a/GitTrends.Shared/Constants/AzureConstants.cs
+++ b/GitTrends.Shared/Constants/AzureConstants.cs
@@ -8,6 +8,7 @@
         public const string GetTestTokenApiKey = "";
         public const string GetSyncFusionInformationApiKey = "";
         public const string GetNotificationHubInformationApiKey = "";
+        public const string GetAppCenterApiKeysKey = "";
         public const string AzureFunctionsApiUrl = "https://gittrendsfunctions.azurewebsites.net/api";
     }
 }

--- a/GitTrends.Shared/Constants/AzureConstants.cs
+++ b/GitTrends.Shared/Constants/AzureConstants.cs
@@ -6,9 +6,9 @@
 #error Missing API Keys
 #endif
         public const string GetTestTokenApiKey = "";
+        public const string GetAppCenterApiKeysKey = "";
         public const string GetSyncFusionInformationApiKey = "";
         public const string GetNotificationHubInformationApiKey = "";
-        public const string GetAppCenterApiKeysKey = "";
         public const string AzureFunctionsApiUrl = "https://gittrendsfunctions.azurewebsites.net/api";
     }
 }

--- a/GitTrends.Shared/GitTrends.Shared.projitems
+++ b/GitTrends.Shared/GitTrends.Shared.projitems
@@ -70,5 +70,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)StringExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefitExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\DTOs\GitTrendsStatisticsDTO.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\DTOs\AppCenterApiKeyDTO.cs" />
   </ItemGroup>
 </Project>

--- a/GitTrends.Shared/Interfaces/IAnalyticsService.cs
+++ b/GitTrends.Shared/Interfaces/IAnalyticsService.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace GitTrends.Shared
 {

--- a/GitTrends.Shared/Interfaces/IAnalyticsService.cs
+++ b/GitTrends.Shared/Interfaces/IAnalyticsService.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GitTrends.Shared
 {

--- a/GitTrends.Shared/Interfaces/IAnalyticsService.cs
+++ b/GitTrends.Shared/Interfaces/IAnalyticsService.cs
@@ -6,6 +6,10 @@ namespace GitTrends.Shared
 {
     public interface IAnalyticsService
     {
+        bool Configured { get; }
+
+        void Start(string apiKey);
+
         void Track(string trackIdentifier, IDictionary<string, string>? table = null);
 
         void Track(string trackIdentifier, string key, string value);

--- a/GitTrends.Shared/Interfaces/IAzureFunctionsApi.cs
+++ b/GitTrends.Shared/Interfaces/IAzureFunctionsApi.cs
@@ -32,6 +32,6 @@ namespace GitTrends.Shared
         Task<GitTrendsStatisticsDTO> GetGitTrendsStatistics();
 
         [Get("/GetAppCenterApiKeys")]
-        Task<AppCenterApiKeyDTO> GetAppCenterApiKeys();
+        Task<AppCenterApiKeyDTO> GetAppCenterApiKeys([AliasAs("code")] string functionKey = AzureConstants.GetAppCenterApiKeysKey);
     }
 }

--- a/GitTrends.Shared/Interfaces/IAzureFunctionsApi.cs
+++ b/GitTrends.Shared/Interfaces/IAzureFunctionsApi.cs
@@ -30,5 +30,8 @@ namespace GitTrends.Shared
 
         [Get("/GetGitTrendsStatistics")]
         Task<GitTrendsStatisticsDTO> GetGitTrendsStatistics();
+
+        [Get("/GetAppCenterApiKeys")]
+        Task<AppCenterApiKeyDTO> GetAppCenterApiKeys();
     }
 }

--- a/GitTrends.Shared/Models/DTOs/AppCenterApiKeyDTO.cs
+++ b/GitTrends.Shared/Models/DTOs/AppCenterApiKeyDTO.cs
@@ -1,0 +1,6 @@
+﻿namespace GitTrends.Shared
+{
+#pragma warning disable IDE1006 // Naming Styles
+    public record AppCenterApiKeyDTO(string iOS, string Android);
+#pragma warning restore IDE1006 // Naming Styles
+}

--- a/GitTrends.UnitTests/MockServices/MockAnalyticsService.cs
+++ b/GitTrends.UnitTests/MockServices/MockAnalyticsService.cs
@@ -9,6 +9,10 @@ namespace GitTrends.UnitTests
 {
     class MockAnalyticsService : IAnalyticsService
     {
+        public bool Configured { get; private set; }
+
+        public void Start(string apiKey) => Configured = true;
+
         public void Track(string trackIdentifier, IDictionary<string, string>? table = null)
         {
             PrintHeader();

--- a/GitTrends.UnitTests/MockServices/MockDeviceInfo.cs
+++ b/GitTrends.UnitTests/MockServices/MockDeviceInfo.cs
@@ -1,14 +1,27 @@
-﻿using Xamarin.Forms;
-using Xamarin.Forms.Internals;
+﻿using System;
+using Xamarin.Essentials;
+using Xamarin.Essentials.Interfaces;
 
 namespace GitTrends.UnitTests
 {
-    class MockDeviceInfo : DeviceInfo
+    class MockDeviceInfo : IDeviceInfo
     {
-        public override Size PixelScreenSize => new Size(0, 0);
+        public MockDeviceInfo() => Version = new Version(VersionString);
 
-        public override Size ScaledScreenSize => new Size(0, 0);
+        public string Model { get; } = "Test";
 
-        public override double ScalingFactor => 1;
+        public string Manufacturer { get; } = "Test";
+
+        public string Name { get; } = "Test";
+
+        public string VersionString { get; } = "1.0";
+
+        public Version Version { get; }
+
+        public DevicePlatform Platform { get; } = DevicePlatform.Android;
+
+        public DeviceIdiom Idiom { get; } = DeviceIdiom.Phone;
+
+        public DeviceType DeviceType { get; } = DeviceType.Unknown;
     }
 }

--- a/GitTrends.UnitTests/MockServices/XamarinFormsDeviceInfo.cs
+++ b/GitTrends.UnitTests/MockServices/XamarinFormsDeviceInfo.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+
+namespace GitTrends.UnitTests
+{
+    class XamarinFormsDeviceInfo : DeviceInfo
+    {
+        public override Size PixelScreenSize => new Size(0, 0);
+
+        public override Size ScaledScreenSize => new Size(0, 0);
+
+        public override double ScalingFactor => 1;
+    }
+}

--- a/GitTrends.UnitTests/ServiceCollection.cs
+++ b/GitTrends.UnitTests/ServiceCollection.cs
@@ -28,6 +28,7 @@ namespace GitTrends.UnitTests
             services.AddSingleton(azureFunctionsApi);
 
             //GitTrends Services
+            services.AddSingleton<AnalyticsInitializationService>();
             services.AddSingleton<AppInitializationService>();
             services.AddSingleton<AzureFunctionsApiService>();
             services.AddSingleton<BackgroundFetchService>();
@@ -67,6 +68,7 @@ namespace GitTrends.UnitTests
             services.AddSingleton<IAnalyticsService, MockAnalyticsService>();
             services.AddSingleton<IAppInfo, MockAppInfo>();
             services.AddSingleton<IBrowser, MockBrowser>();
+            services.AddSingleton<IDeviceInfo, MockDeviceInfo>();
             services.AddSingleton<IDeviceNotificationsService, MockDeviceNotificationsService>();
             services.AddSingleton<IFileSystem, MockFileSystem>();
             services.AddSingleton<IEmail, MockEmail>();

--- a/GitTrends.UnitTests/Tests/Base/BaseTest.cs
+++ b/GitTrends.UnitTests/Tests/Base/BaseTest.cs
@@ -30,7 +30,7 @@ namespace GitTrends.UnitTests
             CultureInfo.DefaultThreadCurrentCulture = null;
             CultureInfo.DefaultThreadCurrentUICulture = null;
 
-            Device.Info = new MockDeviceInfo();
+            Device.Info = new XamarinFormsDeviceInfo();
             Device.PlatformServices = new MockPlatformServices();
 
             var preferences = ServiceCollection.ServiceProvider.GetRequiredService<IPreferences>();

--- a/GitTrends.UnitTests/Tests/Services/AnalyticsInitializationServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/AnalyticsInitializationServiceTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using GitTrends.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace GitTrends.UnitTests
+{
+    class AnalyticsInitializationServiceTests : BaseTest
+    {
+        [Test]
+        public async Task InitalizeTest()
+        {
+            //Arrange
+            bool isConfigured_Initial, isConfigured_Final;
+            var analyticsService = ServiceCollection.ServiceProvider.GetRequiredService<IAnalyticsService>();
+            var analyticsInitializationService = ServiceCollection.ServiceProvider.GetRequiredService<AnalyticsInitializationService>();
+
+            //Act
+            isConfigured_Initial = analyticsService.Configured;
+
+            await analyticsInitializationService.Initialize(CancellationToken.None).ConfigureAwait(false);
+
+            isConfigured_Final = analyticsService.Configured;
+
+            //Assert
+#if AppStore
+            Assert.IsFalse(isConfigured_Initial);
+#else
+            Assert.IsTrue(isConfigured_Initial);
+#endif
+            Assert.IsTrue(isConfigured_Final);
+        }
+    }
+}

--- a/GitTrends.UnitTests/Tests/Services/AzureFunctionsApiServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/AzureFunctionsApiServiceTests.cs
@@ -61,6 +61,7 @@ namespace GitTrends.UnitTests
             Assert.Greater(syncFusionDTO.LicenseVersion, 0);
         }
 
+        [Test]
         public async Task GetChartStreamingUrl()
         {
             //Arrange
@@ -76,6 +77,22 @@ namespace GitTrends.UnitTests
             Assert.IsNotNull(streamingManifest.ManifestUrl);
             Assert.IsFalse(string.IsNullOrWhiteSpace(streamingManifest.HlsUrl));
             Assert.IsFalse(string.IsNullOrWhiteSpace(streamingManifest.ManifestUrl));
+        }
+
+        [Test]
+        public async Task GetAppCenterApiKeys()
+        {
+            //Arrange
+            AppCenterApiKeyDTO? appCenterApiKeyDTO;
+            var azureFunctionsApiService = ServiceCollection.ServiceProvider.GetRequiredService<AzureFunctionsApiService>();
+
+            //Act
+            appCenterApiKeyDTO = await azureFunctionsApiService.GetAppCenterApiKeys(CancellationToken.None).ConfigureAwait(false);
+
+            //Assert
+            Assert.IsNotNull(appCenterApiKeyDTO);
+            Assert.IsNotNull(appCenterApiKeyDTO.iOS);
+            Assert.IsNotNull(appCenterApiKeyDTO.Android);
         }
 
         [Test]

--- a/GitTrends.UnitTests/Tests/Services/AzureFunctionsApiServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/AzureFunctionsApiServiceTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using GitTrends.Shared;
 using Microsoft.Extensions.DependencyInjection;

--- a/GitTrends.iOS/appcenter-pre-build.sh
+++ b/GitTrends.iOS/appcenter-pre-build.sh
@@ -8,6 +8,8 @@ echo "Injecting API Keys"
 
 sed -i '' "s/GetTestTokenApiKey = \"\"/GetTestTokenApiKey = \"$GetTestTokenApiKey\"/g" "$AzureConstantsFile"
 
+sed -i '' "s/GetAppCenterApiKeysKey = \"\"/GetAppCenterApiKeysKey = \"$GetAppCenterApiKeysKey\"/g" "$AzureConstantsFile"
+
 sed -i '' "s/GetSyncFusionInformationApiKey = \"\"/GetSyncFusionInformationApiKey = \"$GetSyncFusionInformationApiKey\"/g" "$AzureConstantsFile"
 
 sed -i '' "s/GetNotificationHubInformationApiKey = \"\"/GetNotificationHubInformationApiKey = \"$GetNotificationHubInformationApiKey\"/g" "$AzureConstantsFile"

--- a/GitTrends/GitTrends.csproj
+++ b/GitTrends/GitTrends.csproj
@@ -13,10 +13,10 @@
       <Optimize>true</Optimize>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' ">
-      <IntermediateOutputPath>obj\AppStore</IntermediateOutputPath>
+      <IntermediateOutputPath>obj\AppStore\netstandard2.1</IntermediateOutputPath>
       <DebugType></DebugType>
       <Optimize>true</Optimize>
-      <OutputPath>bin\AppStore</OutputPath>
+      <OutputPath>bin\AppStore\netstandard2.1</OutputPath>
       <DefineConstants>AppStore</DefineConstants>
       <NoWarn>1701;1702</NoWarn>
       <NoStdLib>false</NoStdLib>

--- a/GitTrends/Services/AnalyticsInitializationService.cs
+++ b/GitTrends/Services/AnalyticsInitializationService.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AppCenter;
+using Microsoft.AppCenter.Analytics;
+using Microsoft.AppCenter.Crashes;
+using Xamarin.Essentials.Interfaces;
+
+namespace GitTrends
+{
+    public class AnalyticsInitializationService
+    {
+        const string _iOSDebugKey = "0e194e2a-3aad-41c5-a6bc-61900e185075";
+        const string _androidDebugKey = "272973ed-d3cc-4ee0-b4f2-5b5d01ad487d";
+
+        readonly IPreferences _preferences;
+        readonly AzureFunctionsApiService _azureFunctionsApiService;
+
+        public AnalyticsInitializationService(IPreferences preferences, AzureFunctionsApiService azureFunctionsApiService)
+        {
+            _preferences = preferences;
+            _azureFunctionsApiService = azureFunctionsApiService;
+
+            if (!string.IsNullOrWhiteSpace(ApiKey))
+                AppCenter.Start(ApiKey, typeof(Analytics), typeof(Crashes));
+        }
+
+        string ApiKey => Xamarin.Forms.Device.RuntimePlatform switch
+        {
+#if AppStore
+
+            Xamarin.Forms.Device.iOS => iOSApiKey,
+            Xamarin.Forms.Device.Android => AndroidApiKey,
+#else
+            Xamarin.Forms.Device.iOS => _iOSDebugKey,
+            Xamarin.Forms.Device.Android => _androidDebugKey,
+#endif
+            _ => throw new NotSupportedException()
+        };
+
+        string AndroidApiKey
+        {
+            get => _preferences.Get(nameof(AndroidApiKey), string.Empty);
+            set => _preferences.Set(nameof(AndroidApiKey), value);
+        }
+
+#pragma warning disable IDE1006 // Naming Styles
+        string iOSApiKey
+        {
+            get => _preferences.Get(nameof(iOSApiKey), string.Empty);
+            set => _preferences.Set(nameof(iOSApiKey), value);
+        }
+#pragma warning restore IDE1006 // Naming Styles
+
+        public async ValueTask Initialize(CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+            {
+                var appCenterApiKeys = await _azureFunctionsApiService.GetAppCenterApiKeys(cancellationToken).ConfigureAwait(false);
+
+                AndroidApiKey = appCenterApiKeys.Android;
+                iOSApiKey = appCenterApiKeys.iOS;
+            }
+
+            var isConfigured = AppCenter.Configured;
+
+            if (!isConfigured)
+                AppCenter.Start(ApiKey, typeof(Analytics), typeof(Crashes));
+        }
+    }
+}

--- a/GitTrends/Services/AnalyticsService.cs
+++ b/GitTrends/Services/AnalyticsService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using GitTrends.Mobile.Common;
 using GitTrends.Shared;
+using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
 
@@ -11,6 +12,10 @@ namespace GitTrends
 {
     public class AnalyticsService : IAnalyticsService
     {
+        public bool Configured => AppCenter.Configured;
+
+        public void Start(string apiKey) =>
+            AppCenter.Start(apiKey, typeof(Analytics), typeof(Crashes));
 
         public void Track(string trackIdentifier, IDictionary<string, string>? table = null) =>
             Analytics.TrackEvent(trackIdentifier, table);

--- a/GitTrends/Services/AnalyticsService.cs
+++ b/GitTrends/Services/AnalyticsService.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using GitTrends.Mobile.Common;
 using GitTrends.Shared;
-using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
 
@@ -12,22 +11,6 @@ namespace GitTrends
 {
     public class AnalyticsService : IAnalyticsService
     {
-#if AppStore
-        const string _iOSKey = "7baad29b-66fa-4c52-8533-217c11595714";
-        const string _androidKey = "d55a09c1-9908-4bc6-99b8-caa4e9083530";
-#else
-        const string _iOSKey = "0e194e2a-3aad-41c5-a6bc-61900e185075";
-        const string _androidKey = "272973ed-d3cc-4ee0-b4f2-5b5d01ad487d";
-#endif
-
-        public AnalyticsService() => AppCenter.Start(ApiKey, typeof(Analytics), typeof(Crashes));
-
-        string ApiKey => Xamarin.Forms.Device.RuntimePlatform switch
-        {
-            Xamarin.Forms.Device.iOS => _iOSKey,
-            Xamarin.Forms.Device.Android => _androidKey,
-            _ => throw new NotSupportedException()
-        };
 
         public void Track(string trackIdentifier, IDictionary<string, string>? table = null) =>
             Analytics.TrackEvent(trackIdentifier, table);

--- a/GitTrends/Services/AppInitializationService.cs
+++ b/GitTrends/Services/AppInitializationService.cs
@@ -19,6 +19,7 @@ namespace GitTrends
         readonly NotificationService _notificationService;
         readonly GitTrendsStatisticsService _gitTrendsStatisticsService;
         readonly IDeviceNotificationsService _deviceNotificationsService;
+        readonly AnalyticsInitializationService _analyticsInitializationService;
 
         public AppInitializationService(ThemeService themeService,
                                         LanguageService languageService,
@@ -28,7 +29,8 @@ namespace GitTrends
                                         MediaElementService mediaElementService,
                                         NotificationService notificationService,
                                         GitTrendsStatisticsService gitTrendsStatisticsService,
-                                        IDeviceNotificationsService deviceNotificationService)
+                                        IDeviceNotificationsService deviceNotificationService,
+                                        AnalyticsInitializationService analyticsInitializationService)
         {
             _themeService = themeService;
             _languageService = languageService;
@@ -39,6 +41,7 @@ namespace GitTrends
             _notificationService = notificationService;
             _deviceNotificationsService = deviceNotificationService;
             _gitTrendsStatisticsService = gitTrendsStatisticsService;
+            _analyticsInitializationService = analyticsInitializationService;
         }
 
         public static event EventHandler<InitializationCompleteEventArgs> InitializationCompleted
@@ -67,6 +70,7 @@ namespace GitTrends
                 var initializeLibrariesServiceValueTask = _librariesService.Initialize(cancellationToken);
                 var initializeNotificationServiceValueTask = _notificationService.Initialize(cancellationToken);
                 var initializeGitTrendsStatisticsValueTask = _gitTrendsStatisticsService.Initialize(cancellationToken);
+                var initializeAnalyticsInitializationServiceTask = _analyticsInitializationService.Initialize(cancellationToken);
 #if DEBUG
                 initializeSyncFusionServiceTask.SafeFireAndForget(ex => _analyticsService.Report(ex));
                 initializeLibrariesServiceValueTask.SafeFireAndForget(ex => _analyticsService.Report(ex));
@@ -76,9 +80,9 @@ namespace GitTrends
                 await initializeLibrariesServiceValueTask.ConfigureAwait(false);
                 await initializeNotificationServiceValueTask.ConfigureAwait(false);
 #endif
-
                 await intializeOnboardingChartValueTask.ConfigureAwait(false);
                 await initializeGitTrendsStatisticsValueTask.ConfigureAwait(false);
+                await initializeAnalyticsInitializationServiceTask.ConfigureAwait(false);
                 #endregion
 
                 isInitializationSuccessful = true;

--- a/GitTrends/Services/AzureFunctionsApiService.cs
+++ b/GitTrends/Services/AzureFunctionsApiService.cs
@@ -22,5 +22,6 @@ namespace GitTrends
         public Task<StreamingManifest> GetChartStreamingUrl(CancellationToken cancellationToken) => AttemptAndRetry_Mobile(() => _azureFunctionsApiClient.GetChartStreamingUrl(), cancellationToken);
         public Task<NotificationHubInformation> GetNotificationHubInformation(CancellationToken cancellationToken) => AttemptAndRetry_Mobile(() => _azureFunctionsApiClient.GetNotificationHubInformation(), cancellationToken);
         public Task<IReadOnlyList<NuGetPackageModel>> GetLibraries(CancellationToken cancellationToken) => AttemptAndRetry_Mobile(() => _azureFunctionsApiClient.GetLibraries(), cancellationToken);
+        public Task<AppCenterApiKeyDTO> GetAppCenterApiKeys(CancellationToken cancellationToken) => AttemptAndRetry_Mobile(() => _azureFunctionsApiClient.GetAppCenterApiKeys(), cancellationToken);
     }
 }

--- a/GitTrends/Services/ContainerService.cs
+++ b/GitTrends/Services/ContainerService.cs
@@ -39,6 +39,7 @@ namespace GitTrends
             //Register Services
             builder.RegisterType<App>().AsSelf().SingleInstance();
             builder.RegisterType<AnalyticsService>().As<IAnalyticsService>().SingleInstance();
+            builder.RegisterType<AnalyticsInitializationService>().AsSelf().SingleInstance();
             builder.RegisterType<AppInitializationService>().AsSelf().SingleInstance();
             builder.RegisterType<AzureFunctionsApiService>().AsSelf().SingleInstance();
             builder.RegisterType<BackgroundFetchService>().AsSelf().SingleInstance();

--- a/GitTrends/Services/ContainerService.cs
+++ b/GitTrends/Services/ContainerService.cs
@@ -28,6 +28,7 @@ namespace GitTrends
             //Register Xamarin.Essentials
             builder.RegisterType<AppInfoImplementation>().As<IAppInfo>().SingleInstance();
             builder.RegisterType<BrowserImplementation>().As<IBrowser>().SingleInstance();
+            builder.RegisterType<DeviceInfoImplementation>().As<IDeviceInfo>().SingleInstance();
             builder.RegisterType<EmailImplementation>().As<IEmail>().SingleInstance();
             builder.RegisterType<FileSystemImplementation>().As<IFileSystem>().SingleInstance();
             builder.RegisterType<LauncherImplementation>().As<ILauncher>().SingleInstance();
@@ -100,7 +101,7 @@ namespace GitTrends
             //Register Refit Services
             IGitHubApiV3 gitHubV3ApiClient = RefitExtensions.For<IGitHubApiV3>(BaseApiService.CreateHttpClient(GitHubConstants.GitHubRestApiUrl));
             IGitHubGraphQLApi gitHubGraphQLApiClient = RefitExtensions.For<IGitHubGraphQLApi>(BaseApiService.CreateHttpClient(GitHubConstants.GitHubGraphQLApi));
-            IAzureFunctionsApi azureFunctionsApiClient = RefitExtensions.For<IAzureFunctionsApi>(BaseApiService.CreateHttpClient(AzureConstants.AzureFunctionsApiUrl)); 
+            IAzureFunctionsApi azureFunctionsApiClient = RefitExtensions.For<IAzureFunctionsApi>(BaseApiService.CreateHttpClient(AzureConstants.AzureFunctionsApiUrl));
 
             builder.RegisterInstance(gitHubV3ApiClient).SingleInstance();
             builder.RegisterInstance(gitHubGraphQLApiClient).SingleInstance();


### PR DESCRIPTION
This pull requests moves the production API Keys used for App Center to avoid Forks/Clones of the repo from accidentally utilizing the keys.