### PR TITLE
Handle Retry Rate Limit

### DIFF
--- a/GitTrends.Android/GitTrends.Android.csproj
+++ b/GitTrends.Android/GitTrends.Android.csproj
@@ -104,8 +104,8 @@
     <PackageReference Include="Xamarin.Google.Dagger" Version="2.37.0" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.3" />
     <PackageReference Include="Refit.Newtonsoft.Json" Version="6.0.38" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.3.2.3" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/GitTrends.Android/Services/NotificationService_Android.cs
+++ b/GitTrends.Android/Services/NotificationService_Android.cs
@@ -75,13 +75,14 @@ namespace GitTrends.Droid
             }
         }
 
-        public override async void OnMessageReceived(RemoteMessage message)
+        public override void OnMessageReceived(RemoteMessage message)
         {
             base.OnMessageReceived(message);
 
             var backgroundFetchService = ContainerService.Container.Resolve<BackgroundFetchService>();
 
-            await Task.WhenAll(backgroundFetchService.CleanUpDatabase(), backgroundFetchService.NotifyTrendingRepositories(CancellationToken.None));
+            backgroundFetchService.ScheduleCleanUpDatabase();
+            backgroundFetchService.ScheduleNotifyTrendingRepositories(CancellationToken.None);
         }
 
         Task RegisterWithNotificationHub(in NotificationHubInformation notificationHubInformation, in string token)

--- a/GitTrends.Shared/Constants/GithubConstants.cs
+++ b/GitTrends.Shared/Constants/GithubConstants.cs
@@ -7,7 +7,7 @@ namespace GitTrends.Shared
         public const string GitHubBaseUrl = "https://github.com";
         public const string GitHubRestApiUrl = "https://api.github.com";
         public const string GitHubGraphQLApi = "https://api.github.com/graphql";
-        public const string GitHubRateLimitingDocs = "https://developer.github.com/v3/#rate-limiting";
+        public const string GitHubRateLimitingDocs = "https://docs.github.com/rest/reference/rate-limit";
 
         public const string GitTrendsRepoName = nameof(GitTrends);
         public const string GitTrendsRepoOwner = "brminnick";

--- a/GitTrends.Shared/Models/Repository.cs
+++ b/GitTrends.Shared/Models/Repository.cs
@@ -45,6 +45,8 @@ namespace GitTrends.Shared
             DailyClonesList = clones?.ToList();
         }
 
+        public bool ContainsTrafficData => TotalClones is not null && TotalViews is not null && TotalUniqueClones is not null && TotalUniqueViews is not null && StarCount is not null;
+
         public DateTimeOffset DataDownloadedAt { get; }
 
         public string OwnerLogin { get; init; }

--- a/GitTrends.UnitTests/MockServices/MockJobManager.cs
+++ b/GitTrends.UnitTests/MockServices/MockJobManager.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shiny;
+using Shiny.Jobs;
+
+namespace GitTrends.UnitTests
+{
+    class MockJobManager : IJobManager
+    {
+        readonly Dictionary<string, JobInfo> _jobDictionary = new();
+
+        public bool IsRunning { get; private set; }
+
+        public IObservable<JobInfo> JobStarted => throw new NotImplementedException();
+
+        public IObservable<JobRunResult> JobFinished => throw new NotImplementedException();
+
+        public Task Cancel(string jobIdentifier)
+        {
+            if (_jobDictionary.TryGetValue(jobIdentifier, out _))
+                _jobDictionary.Remove(jobIdentifier);
+
+            return Task.CompletedTask;
+        }
+
+        public Task CancelAll()
+        {
+            _jobDictionary.Clear();
+            return Task.CompletedTask;
+        }
+
+        public Task<JobInfo?> GetJob(string jobIdentifier)
+        {
+            if (_jobDictionary.TryGetValue(jobIdentifier, out var jobInfo))
+                return Task.FromResult<JobInfo?>(jobInfo);
+
+            return Task.FromResult<JobInfo?>(null);
+        }
+        public Task<IEnumerable<JobInfo>> GetJobs() => Task.FromResult(_jobDictionary.Values.AsEnumerable());
+
+
+        public Task Register(JobInfo jobInfo)
+        {
+            _jobDictionary.Add(jobInfo.Identifier, jobInfo);
+            return Task.CompletedTask;
+        }
+
+        public Task<AccessState> RequestAccess() => Task.FromResult(AccessState.Available);
+
+        public async Task<JobRunResult> Run(string jobIdentifier, CancellationToken cancelToken = default)
+        {
+            var jobInfo = _jobDictionary[jobIdentifier];
+            var jobType = jobInfo.Type;
+
+            var job = (IJob)(Activator.CreateInstance(jobType) ?? throw new NullReferenceException());
+
+            try
+            {
+                await job.Run(jobInfo, cancelToken);
+            }
+            catch (Exception e)
+            {
+                return new JobRunResult(jobInfo, e);
+            }
+
+            return new JobRunResult(jobInfo, null);
+        }
+
+        public async Task<IEnumerable<JobRunResult>> RunAll(CancellationToken cancelToken = default, bool runSequentially = false)
+        {
+            if (runSequentially)
+            {
+                var resultList = new List<JobRunResult>();
+
+                foreach (var job in _jobDictionary)
+                {
+                    var result = await Run(job.Key, CancellationToken.None);
+                    resultList.Add(result);
+                }
+
+                return resultList;
+            }
+            else
+            {
+                return await Task.WhenAll(_jobDictionary.Select(x => Run(x.Key)));
+            }
+        }
+
+        public async void RunTask(string taskName, Func<CancellationToken, Task> task)
+        {
+            IsRunning = true;
+
+            try
+            {
+                await task(CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                IsRunning = false;
+            }
+        }
+    }
+}

--- a/GitTrends.UnitTests/ServiceCollection.cs
+++ b/GitTrends.UnitTests/ServiceCollection.cs
@@ -4,6 +4,7 @@ using GitTrends.Mobile.Common;
 using GitTrends.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Plugin.StoreReview.Abstractions;
+using Shiny.Jobs;
 using Shiny.Notifications;
 using Xamarin.Essentials.Interfaces;
 
@@ -73,6 +74,7 @@ namespace GitTrends.UnitTests
             services.AddSingleton<IFileSystem, MockFileSystem>();
             services.AddSingleton<IEmail, MockEmail>();
             services.AddSingleton<ILauncher, MockLauncher>();
+            services.AddSingleton<IJobManager, MockJobManager>();
             services.AddSingleton<IMainThread, MockMainThread>();
             services.AddSingleton<INotificationManager, MockNotificationManager>();
             services.AddSingleton<ISecureStorage, MockSecureStorage>();

--- a/GitTrends.UnitTests/Tests/Base/BaseTest.cs
+++ b/GitTrends.UnitTests/Tests/Base/BaseTest.cs
@@ -100,7 +100,7 @@ namespace GitTrends.UnitTests
             return new Repository($"Repository " + DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomNumber(),
                                                         DemoUserConstants.Alias, gitTrendsAvatarUrl,
                                                         DemoDataConstants.GetRandomNumber(), DemoDataConstants.GetRandomNumber(),
-                                                        gitTrendsAvatarUrl, false, downloadedAt, false, dailyViewsList, dailyClonesList, DemoDataConstants.GenerateStarredAtDates(DemoDataConstants.GetRandomNumber()));
+                                                        gitTrendsAvatarUrl, false, downloadedAt, RepositoryPermission.ADMIN, false, dailyViewsList, dailyClonesList, DemoDataConstants.GenerateStarredAtDates(DemoDataConstants.GetRandomNumber()));
         }
     }
 }

--- a/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
@@ -41,7 +41,7 @@ namespace GitTrends.UnitTests
             repositoryDatabaseCount_Initial = await getRepositoryDatabaseCount(repositoryDatabase).ConfigureAwait(false);
             referringSitesDatabaseCount_Initial = await getReferringSitesDatabaseCount(referringSitesDatabase, expiredRepository_Initial.Url, unexpiredRepository_Initial.Url).ConfigureAwait(false);
 
-            await backgroundFetchService.CleanUpDatabase().ConfigureAwait(false);
+            await backgroundFetchService.ScheduleCleanUpDatabase().ConfigureAwait(false);
 
             repositoryDatabaseCount_Final = await getRepositoryDatabaseCount(repositoryDatabase).ConfigureAwait(false);
             referringSitesDatabaseCount_Final = await getReferringSitesDatabaseCount(referringSitesDatabase, expiredRepository_Initial.Url, unexpiredRepository_Initial.Url).ConfigureAwait(false);
@@ -103,7 +103,7 @@ namespace GitTrends.UnitTests
             var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
 
             //Act
-            var result = await backgroundFetchService.NotifyTrendingRepositories(CancellationToken.None).ConfigureAwait(false);
+            var result = await backgroundFetchService.ScheduleNotifyTrendingRepositories(CancellationToken.None).ConfigureAwait(false);
 
             //Assert
             Assert.IsFalse(result);
@@ -120,7 +120,7 @@ namespace GitTrends.UnitTests
             var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
 
             //Act
-            var result = await backgroundFetchService.NotifyTrendingRepositories(CancellationToken.None).ConfigureAwait(false);
+            var result = await backgroundFetchService.ScheduleNotifyTrendingRepositories(CancellationToken.None).ConfigureAwait(false);
 
             //Assert
             Assert.IsTrue(gitHubUserService.IsDemoUser);
@@ -139,7 +139,7 @@ namespace GitTrends.UnitTests
             await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
 
             //Act
-            var result = await backgroundFetchService.NotifyTrendingRepositories(CancellationToken.None).ConfigureAwait(false);
+            var result = await backgroundFetchService.ScheduleNotifyTrendingRepositories(CancellationToken.None).ConfigureAwait(false);
 
             //Assert
             Assert.IsFalse(gitHubUserService.IsDemoUser);

--- a/GitTrends.iOS/AppDelegate.cs
+++ b/GitTrends.iOS/AppDelegate.cs
@@ -68,11 +68,12 @@ namespace GitTrends.iOS
             }
         }
 
-        public override async void ReceivedRemoteNotification(UIApplication application, NSDictionary userInfo)
+        public override void ReceivedRemoteNotification(UIApplication application, NSDictionary userInfo)
         {
             var backgroundFetchService = ContainerService.Container.Resolve<BackgroundFetchService>();
 
-            await Task.WhenAll(backgroundFetchService.CleanUpDatabase(), backgroundFetchService.NotifyTrendingRepositories(CancellationToken.None)).ConfigureAwait(false);
+            backgroundFetchService.ScheduleCleanUpDatabase();
+            backgroundFetchService.ScheduleNotifyTrendingRepositories(CancellationToken.None);
         }
 
         public override async void ReceivedLocalNotification(UIApplication application, UILocalNotification notification) =>

--- a/GitTrends/Database/RepositoryDatabase.cs
+++ b/GitTrends/Database/RepositoryDatabase.cs
@@ -10,7 +10,7 @@ namespace GitTrends
 {
     public class RepositoryDatabase : BaseDatabase
     {
-        public RepositoryDatabase(IFileSystem fileSystem, IAnalyticsService analyticsService) : base(fileSystem, analyticsService, TimeSpan.FromDays(90))
+        public RepositoryDatabase(IFileSystem fileSystem, IAnalyticsService analyticsService) : base(fileSystem, analyticsService, TimeSpan.FromDays(14))
         {
 
         }

--- a/GitTrends/Services/ContainerService.cs
+++ b/GitTrends/Services/ContainerService.cs
@@ -7,6 +7,7 @@ using GitTrends.Shared;
 using Plugin.StoreReview;
 using Plugin.StoreReview.Abstractions;
 using Shiny;
+using Shiny.Jobs;
 using Shiny.Notifications;
 using Xamarin.Essentials.Implementation;
 using Xamarin.Essentials.Interfaces;
@@ -66,6 +67,7 @@ namespace GitTrends
             builder.RegisterType<ThemeService>().AsSelf().SingleInstance();
             builder.RegisterType<TrendsChartSettingsService>().AsSelf().SingleInstance();
             builder.RegisterInstance(CrossStoreReview.Current).As<IStoreReview>().SingleInstance();
+            builder.RegisterInstance(ShinyHost.Resolve<IJobManager>()).As<IJobManager>().SingleInstance();
             builder.RegisterInstance(ShinyHost.Resolve<INotificationManager>()).As<INotificationManager>().SingleInstance();
             builder.RegisterInstance(DependencyService.Resolve<IDeviceNotificationsService>()).As<IDeviceNotificationsService>().SingleInstance();
 #if !AppStore

--- a/GitTrends/Services/GitHubGraphQLApiService.cs
+++ b/GitTrends/Services/GitHubGraphQLApiService.cs
@@ -150,14 +150,11 @@ namespace GitTrends
                 {
                     repositories = await finishedTask.ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch(ApiException e) when (_gitHubApiStatusService.IsAbuseRateLimit(e, out var retryDelta))
                 {
-                    AnalyticsService.Report(e, new Dictionary<string, string>
-                    {
-                        { nameof(GitHubApiStatusService) + nameof(GitHubApiStatusService.IsAbuseRateLimit),  _gitHubApiStatusService.IsAbuseRateLimit(e, out _).ToString() }
-                    });
+
 #if AppStore
-#error Investigate this 403 Forbidden error on Azure-Samples org (Abuse Rate Limit)
+#error Queue Retry
 #endif
                 }
 

--- a/GitTrends/ViewModels/RepositoryViewModel.cs
+++ b/GitTrends/ViewModels/RepositoryViewModel.cs
@@ -23,10 +23,10 @@ namespace GitTrends
     {
         readonly static WeakEventManager<PullToRefreshFailedEventArgs> _pullToRefreshFailedEventManager = new();
 
-        readonly ImageCachingService _imageService;
         readonly GitHubUserService _gitHubUserService;
         readonly RepositoryDatabase _repositoryDatabase;
         readonly GitHubApiV3Service _gitHubApiV3Service;
+        readonly ImageCachingService _imageCachingService;
         readonly MobileSortingService _mobileSortingService;
         readonly GitHubApiStatusService _gitHubApiStatusService;
         readonly GitHubGraphQLApiService _gitHubGraphQLApiService;
@@ -44,26 +44,27 @@ namespace GitTrends
         IReadOnlyList<Repository> _visibleRepositoryList = Array.Empty<Repository>();
 
         public RepositoryViewModel(IMainThread mainThread,
-                                    ImageCachingService imageService,
                                     IAnalyticsService analyticsService,
                                     GitHubUserService gitHubUserService,
-                                    MobileSortingService sortingService,
                                     RepositoryDatabase repositoryDatabase,
                                     GitHubApiV3Service gitHubApiV3Service,
+                                    ImageCachingService imageCachingService,
+                                    MobileSortingService mobileSortingService,
                                     GitHubApiStatusService gitHubApiStatusService,
                                     GitHubGraphQLApiService gitHubGraphQLApiService,
                                     GitHubAuthenticationService gitHubAuthenticationService,
                                     GitHubApiRepositoriesService gitHubApiRepositoriesService) : base(analyticsService, mainThread)
         {
             LanguageService.PreferredLanguageChanged += HandlePreferredLanguageChanged;
+            BackgroundFetchService.ScheduleRetryRepositoriesViewsClonesCompleted += HandleScheduleRetryRepositoriesViewsClonesCompleted;
 
             UpdateText();
 
-            _imageService = imageService;
             _gitHubUserService = gitHubUserService;
-            _mobileSortingService = sortingService;
             _repositoryDatabase = repositoryDatabase;
             _gitHubApiV3Service = gitHubApiV3Service;
+            _imageCachingService = imageCachingService;
+            _mobileSortingService = mobileSortingService;
             _gitHubApiStatusService = gitHubApiStatusService;
             _gitHubGraphQLApiService = gitHubGraphQLApiService;
             _gitHubAuthenticationService = gitHubAuthenticationService;
@@ -214,16 +215,17 @@ namespace GitTrends
                     //Call EnsureSuccessStatusCode to confirm the above API calls executed successfully
                     finalResponse = await _gitHubApiV3Service.GetGitHubApiResponse(cancellationTokenSource.Token).ConfigureAwait(false);
                     finalResponse.EnsureSuccessStatusCode();
+
+                    //Rate Limiting may cause some data to not return successfully from the 
+                    var repositoriesFromDatabase = await getDatabaseRepositoriesTask.ConfigureAwait(false);
+
+                    var missingRepositories = _repositoryList.Concat(repositoriesFromDatabase).Where(x => x.ContainsTrafficData)
+                                                                                                .GroupBy(x => x.Url)
+                                                                                                .Where(g => g.Count() is 1)
+                                                                                                .Select(g => g.First());
+
+                    AddRepositoriesToCollection(missingRepositories, _searchBarText);
                 }
-
-                var repositoriesFromDatabase = await getDatabaseRepositoriesTask.ConfigureAwait(false);
-
-                var missingRepositories = _repositoryList.Concat(repositoriesFromDatabase).GroupBy(x => x.Url)
-                                                                                            .Where(g => g.Count() == 1)
-                                                                                            .Select(g => g.First())
-                                                                                            .ToList();
-
-                AddRepositoriesToCollection(missingRepositories, _searchBarText);
 
                 RefreshState = RefreshState.Succeeded;
             }
@@ -325,7 +327,7 @@ namespace GitTrends
             if (_gitHubUserService.IsDemoUser)
                 return;
 
-            foreach (var repository in repositories)
+            foreach (var repository in repositories.Where(x => x.TotalViews is not null && x.TotalClones is not null && x.TotalUniqueViews is not null && x.TotalUniqueClones is not null && x.StarredAt is not null))
             {
                 try
                 {
@@ -378,7 +380,7 @@ namespace GitTrends
 
             VisibleRepositoryList = MobileSortingService.SortRepositories(filteredRepositoryList, sortingOption, isReversed).ToList();
 
-            _imageService.PreloadRepositoryImages(VisibleRepositoryList).SafeFireAndForget(ex => AnalyticsService.Report(ex));
+            _imageCachingService.PreloadRepositoryImages(VisibleRepositoryList).SafeFireAndForget(ex => AnalyticsService.Report(ex));
         }
 
         void UpdateListForLoggedOutUser()
@@ -433,5 +435,7 @@ namespace GitTrends
 
             _pullToRefreshFailedEventManager.RaiseEvent(this, pullToRefreshFailedEventArgs, nameof(PullToRefreshFailed));
         }
+
+        void HandleScheduleRetryRepositoriesViewsClonesCompleted(object sender, Repository e) => AddRepositoriesToCollection(new List<Repository> { e }, _searchBarText);
     }
 }

--- a/GitTrends/ViewModels/RepositoryViewModel.cs
+++ b/GitTrends/ViewModels/RepositoryViewModel.cs
@@ -169,6 +169,7 @@ namespace GitTrends
             {
                 const int minimumBatchCount = 20;
 
+                var getDatabaseRepositoriesTask = _repositoryDatabase.GetRepositories();
                 var favoriteRepositoryUrls = await _repositoryDatabase.GetFavoritesUrls().ConfigureAwait(false);
 
                 var repositoryList = new List<Repository>();
@@ -214,6 +215,15 @@ namespace GitTrends
                     finalResponse = await _gitHubApiV3Service.GetGitHubApiResponse(cancellationTokenSource.Token).ConfigureAwait(false);
                     finalResponse.EnsureSuccessStatusCode();
                 }
+
+                var repositoriesFromDatabase = await getDatabaseRepositoriesTask.ConfigureAwait(false);
+
+                var missingRepositories = _repositoryList.Concat(repositoriesFromDatabase).GroupBy(x => x.Url)
+                                                                                            .Where(g => g.Count() == 1)
+                                                                                            .Select(g => g.First())
+                                                                                            .ToList();
+
+                AddRepositoriesToCollection(missingRepositories, _searchBarText);
 
                 RefreshState = RefreshState.Succeeded;
             }


### PR DESCRIPTION
This Pull Request defers execution of retrieving Views, Clones and Stars data from the GitHub API when the [Rate Limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits) is reached