### PR TITLE
Increase Xamarin.Forms to v5.0.0.2125

### DIFF
--- a/GitTrends.Android/GitTrends.Android.csproj
+++ b/GitTrends.Android/GitTrends.Android.csproj
@@ -81,7 +81,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
     <PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="6.0.0" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Syncfusion.Xamarin.SfChart" Version="19.1.0.66" />
@@ -104,8 +104,6 @@
     <PackageReference Include="Xamarin.Google.Dagger" Version="2.37.0" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.3" />
     <PackageReference Include="Refit.Newtonsoft.Json" Version="6.0.94" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.3.2.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/GitTrends.iOS/GitTrends.iOS.csproj
+++ b/GitTrends.iOS/GitTrends.iOS.csproj
@@ -444,7 +444,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
     <PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="6.0.0" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="Syncfusion.Xamarin.SfChart" Version="19.1.0.66" />

--- a/GitTrends/GitTrends.csproj
+++ b/GitTrends/GitTrends.csproj
@@ -29,7 +29,7 @@
         <PackageReference Include="HtmlAgilityPack" Version="1.11.36" />
         <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.3.0" />
         <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.3.0" />
-        <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+        <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
         <PackageReference Include="Shiny.Notifications" Version="2.2.0.2829" />
         <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.763-beta" />
         <PackageReference Include="Plugin.StoreReview" Version="3.2.0-beta" />


### PR DESCRIPTION
This PR increases Xamarin.Forms to v5.0.0.2125 and removes the now unnecessary `Xamarin.AndroidX.*` NuGet packages.

The previous release of Xamarin.Forms limited the `Xamarin.AndroidX.*` versions causing NuGet conflicts as detailed here: https://github.com/xamarin/Xamarin.Forms/issues/14417