### PR TITLE
Fix Android CI Build Errors

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -15,6 +15,14 @@ jobs:
       steps:
       - uses: actions/checkout@v1
 
+      - name: Install Boots
+        run : |
+          dotnet tool install --global boots
+          boots --stable Mono
+          boots --preview Xamarin.Android
+          boots --preview Xamarin.iOS
+          boots --preview Xamarin.Mac
+
       - name: Restore NuGet 
         run: |
           nuget restore


### PR DESCRIPTION
This PR is intended to fix the failing Android CI Build after updating to Android v12.0