### PR TITLE
Reverted word in German translation to English

### DIFF
--- a/GitTrends.Mobile.Common/Constants/ManageOrganizationsConstants.de.resx
+++ b/GitTrends.Mobile.Common/Constants/ManageOrganizationsConstants.de.resx
@@ -28,7 +28,7 @@
     <value>Zugriff erlauben</value>
   </data>
 	<data name="EnableOrganizationsDescription" xml:space="preserve">
-    <value>Erlaube Zufriff für Organisation durch Runterscrollen, Auffinden der Organisation und Auswahl von "Anfordern"</value>
+    <value>Erlaube Zufriff für Organisation durch Runterscrollen, Auffinden der Organisation und Auswahl von "Request"</value>
   </data>
 </root>
 


### PR DESCRIPTION
Changed term on Github website to English, as it is not localized into German on the Github side.