### PR TITLE
Fix Resx key typo

### DIFF
--- a/GitTrends.Mobile.Common/Constants/ManageOrganizationsConstants.nl.resx
+++ b/GitTrends.Mobile.Common/Constants/ManageOrganizationsConstants.nl.resx
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+	<data name="GitHubOrganizationsTitle" xml:space="preserve">
+    <value>Organisaties</value>
+  </data>
+	<data name="GitHubOrganizationsDescription" xml:space="preserve">
+    <value>GitHub Organizations (organisaties) zijn gedeelde accounts waarmee teams gemakkelijk kunnen samenwerken aan projecten</value>
+  </data>
+	<data name="GitTrendsAccessTitle" xml:space="preserve">
+    <value>Toegang</value>
+  </data>
+	<data name="GitTrendsAccessDescription" xml:space="preserve">
+    <value>Toegang tot een organisatie dient handmatig, voor iedere organisatie te worden toegestaan</value>
+  </data>
+	<data name="EnableOrganizationsTitle" xml:space="preserve">
+    <value>Toegang Toestaan</value>
+  </data>
+	<data name="EnableOrganizationsDescription" xml:space="preserve">
+    <value>Sta toegang tot een organisatie toe door naar beneden te scrollen, je gewenste organisatie te localiseren en op "Request" (aanvragen) te drukken</value>
+  </data>
+</root>
+

--- a/GitTrends.Mobile.Common/Constants/PullToRefreshFailedConstants.nl.resx
+++ b/GitTrends.Mobile.Common/Constants/PullToRefreshFailedConstants.nl.resx
@@ -27,4 +27,16 @@
 	<data name="LearnMore" space="preserve">
 		<value>Meer information</value>
 	</data>
+	<data name="AbuseLimitReached" space="preserve">
+		<value>GitHub API Limiet Bereikt</value>
+	</data>
+	<data name="GitHubApiAbuseLimit" space="preserve">
+		<value>De GitHub API limiteert soms onze API verzoeken</value>
+	</data>
+	<data name="AbuseLimitAutomaticRetry" space="preserve">
+		<value>We proberen automatisch de data nogmaals te verversen in de achtergrond over ongeveer {0} seconden</value>
+	</data>
+	<data name="AbuseLimitManualRetry" space="preserve">
+		<value>Sluit GitTrends en probeer het nogmaals over ongeveer {0} seconden</value>
+	</data>
 </root>

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.Designer.cs
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.Designer.cs
@@ -77,9 +77,9 @@ namespace GitTrends.Mobile.Common.Constants {
             }
         }
         
-        public static string IncludeOrganziations {
+        public static string IncludeOrganizations {
             get {
-                return ResourceManager.GetString("IncludeOrganziations", resourceCulture);
+                return ResourceManager.GetString("IncludeOrganizations", resourceCulture);
             }
         }
         

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.cs.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.cs.resx
@@ -27,7 +27,7 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Aplikaci vytvořil Code Traveler LLC</value>
   </data>
-  	<data name="IncludeOrganziations" xml:space="preserve">
+  	<data name="IncludeOrganizations" xml:space="preserve">
     <value>Zahrnout Organizace</value>
   </data>
 	<data name="ManageOrganizations" xml:space="preserve">

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.de.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.de.resx
@@ -27,7 +27,7 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Erstellt von Code Traveler LLC</value>
   </data>
-	<data name="IncludeOrganziations" xml:space="preserve">
+	<data name="IncludeOrganizations" xml:space="preserve">
     <value>Organisationen einbinden</value>
   </data>
 	<data name="ManageOrganizations" xml:space="preserve">

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.en.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.en.resx
@@ -27,7 +27,7 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Created by Code Traveler LLC</value>
   </data>
-	<data name="IncludeOrganziations" xml:space="preserve">
+	<data name="IncludeOrganizations" xml:space="preserve">
     <value>Include Organizations</value>
   </data>
 	<data name="ManageOrganizations" xml:space="preserve">

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.es.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.es.resx
@@ -27,7 +27,7 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Creado por Code Traveler LLC</value>
   </data>
-	<data name="IncludeOrganziations" xml:space="preserve">
+	<data name="IncludeOrganizations" xml:space="preserve">
     <value>Incluir Organizaciones</value>
   </data>
 	<data name="ManageOrganizations" xml:space="preserve">

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.nl.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.nl.resx
@@ -27,4 +27,10 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Gemaakt door Code Traveler LLC</value>
   </data>
+	<data name="IncludeOrganziations" xml:space="preserve">
+    <value>Organisaties Inschakelen</value>
+  </data>
+	<data name="ManageOrganizations" xml:space="preserve">
+    <value>Organisaties Beheren</value>
+  </data>
 </root>

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.nl.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.nl.resx
@@ -27,7 +27,7 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Gemaakt door Code Traveler LLC</value>
   </data>
-	<data name="IncludeOrganziations" xml:space="preserve">
+	<data name="IncludeOrganizations" xml:space="preserve">
     <value>Organisaties Inschakelen</value>
   </data>
 	<data name="ManageOrganizations" xml:space="preserve">

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.pt.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.pt.resx
@@ -15,7 +15,7 @@
   <data name="CreatedBy" xml:space="preserve">
     <value>Criado por Code Traveler LLC</value>
   </data>
-  <data name="IncludeOrganziations" xml:space="preserve">
+  <data name="IncludeOrganizations" xml:space="preserve">
     <value>Incluir Organizações</value>
   </data>
   <data name="Language" xml:space="preserve">

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.resx
@@ -27,7 +27,7 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Created by Code Traveler LLC</value>
   </data>
-	<data name="IncludeOrganziations" xml:space="preserve">
+	<data name="IncludeOrganizations" xml:space="preserve">
     <value>Include Organizations</value>
   </data>
 	<data name="ManageOrganizations" xml:space="preserve">

--- a/GitTrends.Mobile.Common/Constants/SettingsPageConstants.ru.resx
+++ b/GitTrends.Mobile.Common/Constants/SettingsPageConstants.ru.resx
@@ -27,7 +27,7 @@
 	<data name="CreatedBy" xml:space="preserve">
     <value>Создано Code Traveler LLC</value>
   </data>
-	<data name="IncludeOrganziations" xml:space="preserve">
+	<data name="IncludeOrganizations" xml:space="preserve">
     <value>Включить Организации</value>
   </data>
 	<data name="ManageOrganizations" xml:space="preserve">

--- a/GitTrends.UnitTests/Tests/Services/GitHubUserServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubUserServiceTests.cs
@@ -201,13 +201,13 @@ namespace GitTrends.UnitTests
 			shouldIncludeOrganizations_Initial = gitHubUserService.ShouldIncludeOrganizations;
 
 			gitHubUserService.ShouldIncludeOrganizations = !gitHubUserService.ShouldIncludeOrganizations;
-			var shouldIncludeOrganziationsChangedResult = await shouldIncludeOrganizationsChangedTCS.Task.ConfigureAwait(false);
+			var shouldIncludeOrganizationsChangedResult = await shouldIncludeOrganizationsChangedTCS.Task.ConfigureAwait(false);
 
 			shouldIncludeOrganizations_Final = gitHubUserService.ShouldIncludeOrganizations;
 
 			//Assert
 			Assert.IsFalse(shouldIncludeOrganizations_Initial);
-			Assert.IsTrue(shouldIncludeOrganziationsChangedResult);
+			Assert.IsTrue(shouldIncludeOrganizationsChangedResult);
 			Assert.IsTrue(shouldIncludeOrganizations_Final);
 
 			void HandleShouldIncludeOrganizationsChanged(object? sender, bool e)

--- a/GitTrends/ViewModels/SettingsViewModel.cs
+++ b/GitTrends/ViewModels/SettingsViewModel.cs
@@ -445,7 +445,7 @@ namespace GitTrends
 			CopyrightLabelText = $"{getVersionNumberText(_versionTracking)}\n{SettingsPageConstants.CreatedBy}";
 			PreferredChartsLabelText = SettingsPageConstants.PreferredChartSettingsLabelText;
 			RegisterForNotificationsLabelText = SettingsPageConstants.RegisterForNotifications;
-			ShouldIncludeOrganizationsLabelText = SettingsPageConstants.IncludeOrganziations;
+			ShouldIncludeOrganizationsLabelText = SettingsPageConstants.IncludeOrganizations;
 
 			ThemePickerItemsSource = ThemePickerConstants.ThemePickerTitles.Values.ToList();
 			PreferredChartsItemsSource = TrendsChartConstants.TrendsChartTitles.Values.ToList();


### PR DESCRIPTION
While doing the Dutch translations in #363 I noticed there was a typo in one of the Resx keys.

`IncludeOrganziations` -> `IncludeOrganizations`.

This also has the commits for the Dutch translations, so you could merge this and close #363 or maybe you have some other changes going on and you merge the translations first and then (later) this one :) up to you!

Closes #363