### PR TITLE
Optimize StarGazer Query

### DIFF
--- a/GitTrends.Functions/Functions/UpdateGitTrendsStatistics.cs
+++ b/GitTrends.Functions/Functions/UpdateGitTrendsStatistics.cs
@@ -30,7 +30,7 @@ namespace GitTrends.Functions
 			var contributors = await getGitTrendsContributorsTask.ConfigureAwait(false);
 
 			var statistics = new GitTrendsStatisticsDTO(new Uri(repository.Url ?? throw new NullReferenceException()),
-															repository.StarCount ?? throw new NullReferenceException(),
+															repository.StarCount,
 															repository.WatchersCount,
 															repository.ForkCount,
 															contributors);

--- a/GitTrends.Shared/Interfaces/IGitHubApiV3.cs
+++ b/GitTrends.Shared/Interfaces/IGitHubApiV3.cs
@@ -41,7 +41,7 @@ namespace GitTrends.Shared
 		[Get("/repos/{owner}/{repo}")]
 		Task<GetRepositoryResponse> GetRepository(string owner, string repo, [Header("Authorization")] string authorization);
 
-		[Get("/repos/{owner}/{repo}/stargazers?per_page=100")]
-		Task<IReadOnlyList<StarGazer>> GetStarGazers(string owner, string repo, [AliasAs("page")] int currentPageNumber, [Header("Authorization")] string authorization, [Header("Accept")] string accept = "application/vnd.github.v3.star+json");
+		[Get("/repos/{owner}/{repo}/stargazers")]
+		Task<IReadOnlyList<StarGazer>> GetStarGazers(string owner, string repo, [AliasAs("page")] int currentPageNumber, [Header("Authorization")] string authorization, [AliasAs("per_page")] int starGazersPerRequest = 100, [Header("Accept")] string accept = "application/vnd.github.v3.star+json");
 	}
 }

--- a/GitTrends.Shared/Interfaces/IGitHubApiV3.cs
+++ b/GitTrends.Shared/Interfaces/IGitHubApiV3.cs
@@ -41,7 +41,7 @@ namespace GitTrends.Shared
 		[Get("/repos/{owner}/{repo}")]
 		Task<GetRepositoryResponse> GetRepository(string owner, string repo, [Header("Authorization")] string authorization);
 
-		[Get("/repos/{owner}/{repo}/stargazers")]
-		Task<IReadOnlyList<StarGazer>> GetStarGazers(string owner, string repo, [Header("Authorization")] string authorization, [Header("Accept")] string accept = "application/vnd.github.v3.star+json");
+		[Get("/repos/{owner}/{repo}/stargazers?per_page=100")]
+		Task<IReadOnlyList<StarGazer>> GetStarGazers(string owner, string repo, [AliasAs("page")] int currentPageNumber, [Header("Authorization")] string authorization, [Header("Accept")] string accept = "application/vnd.github.v3.star+json");
 	}
 }

--- a/GitTrends.Shared/Interfaces/IGitHubApiV3.cs
+++ b/GitTrends.Shared/Interfaces/IGitHubApiV3.cs
@@ -40,5 +40,8 @@ namespace GitTrends.Shared
 
 		[Get("/repos/{owner}/{repo}")]
 		Task<GetRepositoryResponse> GetRepository(string owner, string repo, [Header("Authorization")] string authorization);
+
+		[Get("/repos/{owner}/{repo}/stargazers")]
+		Task<IReadOnlyList<StarGazer>> GetStarGazers(string owner, string repo, [Header("Authorization")] string authorization, [Header("Accept")] string accept = "application/vnd.github.v3.star+json");
 	}
 }

--- a/GitTrends.Shared/Interfaces/IGitHubGraphQLAPI.cs
+++ b/GitTrends.Shared/Interfaces/IGitHubGraphQLAPI.cs
@@ -63,7 +63,7 @@ namespace GitTrends.Shared
 	public record UserRepositoryConnectionQueryContent : GraphQLRequest
 	{
 		public UserRepositoryConnectionQueryContent(string repositoryOwner, string endCursorString, int numberOfRepositoriesPerRequest = 100)
-			: base("query{ user(login: \"" + repositoryOwner + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
+			: base("query{ user(login: \"" + repositoryOwner + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }, stargazers { totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
 		{
 
 		}
@@ -72,7 +72,7 @@ namespace GitTrends.Shared
 	public record OrganizationRepositoryConnectionQueryContent : GraphQLRequest
 	{
 		public OrganizationRepositoryConnectionQueryContent(string organization, string endCursorString, int numberOfRepositoriesPerRequest = 100)
-			: base("query{ organization(login: \"" + organization + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
+			: base("query{ organization(login: \"" + organization + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }, stargazers { totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
 		{
 
 		}

--- a/GitTrends.Shared/Models/DTOs/StarGazers.cs
+++ b/GitTrends.Shared/Models/DTOs/StarGazers.cs
@@ -25,4 +25,6 @@ namespace GitTrends.Shared
 
 		public DateTimeOffset StarredAt { get; }
 	}
+
+	public record StarGazersConnection(long TotalCount);
 }

--- a/GitTrends.Shared/Models/DTOs/StarGazers.cs
+++ b/GitTrends.Shared/Models/DTOs/StarGazers.cs
@@ -18,4 +18,11 @@ namespace GitTrends.Shared
 	}
 
 	public record StarGazerInfo(DateTimeOffset StarredAt, string Cursor);
+
+	public record StarGazer
+	{
+		public StarGazer(DateTimeOffset starred_at) => StarredAt = starred_at;
+
+		public DateTimeOffset StarredAt { get; }
+	}
 }

--- a/GitTrends.Shared/Models/GetRepositoryResponse.cs
+++ b/GitTrends.Shared/Models/GetRepositoryResponse.cs
@@ -33,7 +33,7 @@ namespace GitTrends.Shared
 
 		public string OwnerAvatarUrl { get; }
 
-		public long? StarCount { get; }
+		public long StarCount { get; }
 
 		public long IssuesCount { get; }
 

--- a/GitTrends.Shared/Models/Interfaces/IRepository.cs
+++ b/GitTrends.Shared/Models/Interfaces/IRepository.cs
@@ -7,7 +7,7 @@ namespace GitTrends.Shared
 		DateTimeOffset DataDownloadedAt { get; }
 		string OwnerLogin { get; }
 		string OwnerAvatarUrl { get; }
-		long? StarCount { get; }
+		long StarCount { get; }
 		long IssuesCount { get; }
 		string Name { get; }
 		string Description { get; }

--- a/GitTrends.Shared/Models/Repository.cs
+++ b/GitTrends.Shared/Models/Repository.cs
@@ -18,6 +18,7 @@ namespace GitTrends.Shared
 							string ownerAvatarUrl,
 							long issuesCount,
 							long watchersCount,
+							long starCount,
 							string url,
 							bool isFork,
 							DateTimeOffset dataDownloadedAt,
@@ -37,16 +38,17 @@ namespace GitTrends.Shared
 			OwnerLogin = ownerLogin;
 			OwnerAvatarUrl = ownerAvatarUrl;
 			IssuesCount = issuesCount;
+			StarCount = starCount;
 			IsFork = isFork;
 			Url = url;
 			Permission = permission;
-
 			StarredAt = starredAt?.ToList();
 			DailyViewsList = views?.ToList();
 			DailyClonesList = clones?.ToList();
 		}
 
-		public bool ContainsTrafficData => TotalClones is not null && TotalViews is not null && TotalUniqueClones is not null && TotalUniqueViews is not null && StarCount is not null;
+		public bool ContainsViewsClonesStarsData => TotalClones is not null && TotalViews is not null && TotalUniqueClones is not null && TotalUniqueViews is not null && StarredAt is not null;
+		public bool ContainsViewsClonesData => TotalClones is not null && TotalViews is not null && TotalUniqueClones is not null && TotalUniqueViews is not null;
 
 		public DateTimeOffset DataDownloadedAt { get; init; }
 		public string OwnerLogin { get; init; }
@@ -56,6 +58,7 @@ namespace GitTrends.Shared
 		public string Description { get; init; }
 		public long WatchersCount { get; init; }
 		public long ForkCount { get; init; }
+		public long StarCount { get; init; }
 		public bool IsFork { get; init; }
 		public string Url { get; init; }
 		public RepositoryPermission Permission { get; init; }
@@ -95,18 +98,13 @@ namespace GitTrends.Shared
 		public IReadOnlyList<DateTimeOffset>? StarredAt
 		{
 			get => _starredAt;
-			init
-			{
-				_starredAt = value?.OrderBy(x => x).ToList();
-				StarCount = value?.Count;
-			}
+			init => _starredAt = value?.OrderBy(x => x).ToList();
 		}
 
 		public long? TotalViews { get; private init; }
 		public long? TotalUniqueViews { get; private init; }
 		public long? TotalClones { get; private init; }
 		public long? TotalUniqueClones { get; private init; }
-		public long? StarCount { get; private init; }
 		public bool IsTrending { get; private init; }
 
 		public override string ToString()

--- a/GitTrends.Shared/Models/RepositoryConnection.cs
+++ b/GitTrends.Shared/Models/RepositoryConnection.cs
@@ -20,7 +20,7 @@ namespace GitTrends.Shared
 		public PageInfo PageInfo { get; }
 	}
 
-	public record RepositoryConnectionNode(string ViewerPermission, string Name, string Description, long ForkCount, Uri Url, RepositoryOwner Owner, bool IsFork, IssuesConnection Issues, Watchers Watchers)
+	public record RepositoryConnectionNode(string ViewerPermission, string Name, string Description, long ForkCount, Uri Url, RepositoryOwner Owner, bool IsFork, IssuesConnection Issues, Watchers Watchers, StarGazersConnection Stargazers)
 	{
 		public DateTimeOffset DataDownloadedAt { get; } = DateTimeOffset.UtcNow;
 

--- a/GitTrends.Shared/Services/RepositoryService.cs
+++ b/GitTrends.Shared/Services/RepositoryService.cs
@@ -6,7 +6,11 @@ namespace GitTrends.Shared
 {
 	public static class RepositoryService
 	{
-		public static IEnumerable<Repository> RemoveForksAndDuplicates(this IEnumerable<Repository> repositoriesList, Func<Repository, bool> duplicateRepositoryPriorityFilter) =>
-			repositoriesList.Where(x => !x.IsFork).OrderByDescending(x => x.DataDownloadedAt).GroupBy(x => x.Name).Select(x => x.FirstOrDefault(duplicateRepositoryPriorityFilter) ?? x.First());
+		public static IEnumerable<Repository> RemoveForksAndDuplicates(this IEnumerable<Repository> repositoriesList, Func<Repository, bool>? duplicateRepositoryPriorityFilter = null)
+		{
+			duplicateRepositoryPriorityFilter ??= _ => true;
+
+			return repositoriesList.Where(x => !x.IsFork).OrderByDescending(x => x.DataDownloadedAt).GroupBy(x => x.Name).Select(x => x.FirstOrDefault(duplicateRepositoryPriorityFilter) ?? x.First());
+		}
 	}
 }

--- a/GitTrends.Shared/Services/RepositoryService.cs
+++ b/GitTrends.Shared/Services/RepositoryService.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GitTrends.Shared
 {
 	public static class RepositoryService
 	{
-		public static IEnumerable<Repository> RemoveForksAndDuplicates(in IEnumerable<Repository> repositoriesList) =>
-			repositoriesList.Where(x => !x.IsFork).OrderByDescending(x => x.DataDownloadedAt).GroupBy(x => x.Name).Select(x => x.FirstOrDefault(x => x.ContainsTrafficData) ?? x.First());
+		public static IEnumerable<Repository> RemoveForksAndDuplicates(this IEnumerable<Repository> repositoriesList, Func<Repository, bool> duplicateRepositoryPriorityFilter) =>
+			repositoriesList.Where(x => !x.IsFork).OrderByDescending(x => x.DataDownloadedAt).GroupBy(x => x.Name).Select(x => x.FirstOrDefault(duplicateRepositoryPriorityFilter) ?? x.First());
 	}
 }

--- a/GitTrends.UITests/Models/Repository.cs
+++ b/GitTrends.UITests/Models/Repository.cs
@@ -11,7 +11,7 @@ namespace GitTrends.UITests
 
 		public string OwnerLogin { get; init; } = string.Empty;
 
-		public long? StarCount { get; init; }
+		public long StarCount { get; init; }
 
 		public long IssuesCount { get; init; }
 

--- a/GitTrends.UnitTests/Tests/Base/BaseTest.cs
+++ b/GitTrends.UnitTests/Tests/Base/BaseTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GitTrends.Mobile.Common;
@@ -98,10 +99,12 @@ namespace GitTrends.UnitTests
 				dailyClonesList.Add(new DailyClonesModel(downloadedAt.Subtract(TimeSpan.FromDays(i)), count, uniqeCount));
 			}
 
+			var starredAt = DemoDataConstants.GenerateStarredAtDates(DemoDataConstants.GetRandomNumber()).ToList();
+
 			return new Repository($"Repository " + DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomNumber(),
 														DemoUserConstants.Alias, gitTrendsAvatarUrl,
-														DemoDataConstants.GetRandomNumber(), DemoDataConstants.GetRandomNumber(),
-														gitTrendsAvatarUrl, false, downloadedAt, RepositoryPermission.ADMIN, false, dailyViewsList, dailyClonesList, DemoDataConstants.GenerateStarredAtDates(DemoDataConstants.GetRandomNumber()));
+														DemoDataConstants.GetRandomNumber(), DemoDataConstants.GetRandomNumber(), starredAt.Count,
+														gitTrendsAvatarUrl, false, downloadedAt, RepositoryPermission.ADMIN, false, dailyViewsList, dailyClonesList, starredAt);
 		}
 	}
 }

--- a/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
@@ -34,8 +34,8 @@ namespace GitTrends.UnitTests
 												GitHubConstants.GitTrendsAvatarUrl, 1, 2, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			//Act
-			wasScheduledSuccessfully_First = backgroundFetchService.TryScheduleRetryRepositoriesViewsClones(repository_Initial);
-			wasScheduledSuccessfully_Second = backgroundFetchService.TryScheduleRetryRepositoriesViewsClones(repository_Initial);
+			wasScheduledSuccessfully_First = backgroundFetchService.TryScheduleRetryRepositoriesViewsClonesStars(repository_Initial);
+			wasScheduledSuccessfully_Second = backgroundFetchService.TryScheduleRetryRepositoriesViewsClonesStars(repository_Initial);
 
 			repository_Final = await scheduleRetryRepositoriesViewsClonesCompletedTCS.Task.ConfigureAwait(false);
 			repository_Database = await repositoryDatabase.GetRepository(repository_Initial.Url).ConfigureAwait(false) ?? throw new NullReferenceException();

--- a/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
@@ -44,9 +44,9 @@ namespace GitTrends.UnitTests
 			Assert.IsTrue(wasScheduledSuccessfully_First);
 			Assert.IsFalse(wasScheduledSuccessfully_Second);
 
-			Assert.IsFalse(repository_Initial.ContainsTrafficData);
-			Assert.IsTrue(repository_Final.ContainsTrafficData);
-			Assert.IsTrue(repository_Database.ContainsTrafficData);
+			Assert.IsFalse(repository_Initial.ContainsViewsClonesStarsData);
+			Assert.IsTrue(repository_Final.ContainsViewsClonesStarsData);
+			Assert.IsTrue(repository_Database.ContainsViewsClonesStarsData);
 
 			Assert.IsNull(repository_Initial.DailyClonesList);
 			Assert.IsNull(repository_Initial.DailyViewsList);
@@ -129,8 +129,8 @@ namespace GitTrends.UnitTests
 
 			Assert.AreEqual(organizationName_Initial, organizationName_Final);
 
-			Assert.IsTrue(repository_Final.ContainsTrafficData);
-			Assert.IsTrue(repository_Database.ContainsTrafficData);
+			Assert.IsTrue(repository_Final.ContainsViewsClonesStarsData);
+			Assert.IsTrue(repository_Database.ContainsViewsClonesStarsData);
 
 			Assert.IsNotNull(repository_Final.DailyClonesList);
 			Assert.IsNotNull(repository_Final.DailyViewsList);
@@ -239,7 +239,7 @@ namespace GitTrends.UnitTests
 
 			Assert.AreEqual(repository_Initial.ToString(), repository_Final.ToString());
 
-			Assert.AreEqual(repository_Initial.ContainsTrafficData, repository_Final.ContainsTrafficData);
+			Assert.AreEqual(repository_Initial.ContainsViewsClonesStarsData, repository_Final.ContainsViewsClonesStarsData);
 			Assert.AreEqual(repository_Initial.DailyClonesList?.Count, repository_Final.DailyClonesList?.Count);
 			Assert.AreEqual(repository_Initial.DailyViewsList?.Count, repository_Final.DailyViewsList?.Count);
 			Assert.AreEqual(repository_Initial.DataDownloadedAt, repository_Final.DataDownloadedAt);

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
@@ -44,9 +44,9 @@ namespace GitTrends.UnitTests
 				repositories_NoViewsClonesData.Add(repository);
 			}
 
-			repositories_NoViewsClonesData_Filtered = RepositoryService.RemoveForksAndDuplicates(repositories_NoViewsClonesData).ToList();
+			repositories_NoViewsClonesData_Filtered = repositories_NoViewsClonesData.RemoveForksAndDuplicates().ToList();
 
-			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsClonesAndStarsData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories.Add(repository);
 			}
@@ -94,7 +94,7 @@ namespace GitTrends.UnitTests
 
 			var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
 			{
-				await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsClonesAndStarsData(repositories_NoViewsClonesData, CancellationToken.None).ConfigureAwait(false))
+				await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesData, CancellationToken.None).ConfigureAwait(false))
 				{
 					repositories.Add(repository);
 				}
@@ -113,7 +113,7 @@ namespace GitTrends.UnitTests
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
 			//Act
-			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsClonesAndStarsData(new List<Repository>(), CancellationToken.None).ConfigureAwait(false))
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(new List<Repository>(), CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories.Add(repository);
 			}
@@ -141,11 +141,11 @@ namespace GitTrends.UnitTests
 				repositories_NoViewsClonesData.Add(repository);
 			}
 
-			repositories_NoViewsClonesData_Filtered = RepositoryService.RemoveForksAndDuplicates(repositories_NoViewsClonesData).ToList();
+			repositories_NoViewsClonesData_Filtered = repositories_NoViewsClonesData.RemoveForksAndDuplicates().ToList();
 
 			gitHubUserService.InvalidateToken();
 
-			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsClonesAndStarsData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories.Add(repository);
 			};
@@ -176,9 +176,9 @@ namespace GitTrends.UnitTests
 				repositories_NoViewsClonesData.Add(repository);
 			}
 
-			repositories_NoViewsClonesData_Filtered = RepositoryService.RemoveForksAndDuplicates(repositories_NoViewsClonesData).ToList();
+			repositories_NoViewsClonesData_Filtered = repositories_NoViewsClonesData.RemoveForksAndDuplicates().ToList();
 
-			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsClonesAndStarsData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories.Add(repository);
 			};

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
@@ -26,13 +26,15 @@ namespace GitTrends.UnitTests
 		}
 
 		[Test]
-		public async Task UpdateRepositoriesWithViewsAndClonesData_ValidRepo()
+		public async Task UpdateRepositoriesWithViewsClonesStarsData_ValidRepo()
 		{
 			//Arrange
-			IReadOnlyList<Repository> repositories_NoViewsClonesData_Filtered;
+			IReadOnlyList<Repository> repositories_Filtered;
+			IReadOnlyList<Repository> repositories_NoViewsClonesStarsData_Filtered;
 
 			var repositories = new List<Repository>();
-			var repositories_NoViewsClonesData = new List<Repository>();
+			var repositories_NoStarsData = new List<Repository>();
+			var repositories_NoViewsClonesStarsData = new List<Repository>();
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
@@ -41,27 +43,44 @@ namespace GitTrends.UnitTests
 			//Act
 			await foreach (var repository in gitHubGraphQLApiService.GetRepositories(gitHubUserService.Alias, CancellationToken.None).ConfigureAwait(false))
 			{
-				repositories_NoViewsClonesData.Add(repository);
+				repositories_NoViewsClonesStarsData.Add(repository);
 			}
 
-			repositories_NoViewsClonesData_Filtered = repositories_NoViewsClonesData.RemoveForksAndDuplicates().ToList();
+			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksAndDuplicates().ToList();
 
-			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			{
+				repositories_NoStarsData.Add(repository);
+			}
+
+			repositories_Filtered = repositories_NoStarsData.RemoveForksAndDuplicates().ToList();
+
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(repositories_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories.Add(repository);
 			}
 
 			//Assert
 			Assert.IsNotEmpty(repositories);
-			Assert.IsNotEmpty(repositories_NoViewsClonesData);
+			Assert.IsNotEmpty(repositories_NoStarsData);
+			Assert.IsNotEmpty(repositories_NoViewsClonesStarsData);
 
-			foreach (var repository in repositories_NoViewsClonesData)
+			foreach (var repository in repositories_NoViewsClonesStarsData)
 			{
 				Assert.IsNull(repository.StarredAt);
 				Assert.IsNull(repository.TotalClones);
 				Assert.IsNull(repository.TotalUniqueClones);
 				Assert.IsNull(repository.TotalViews);
 				Assert.IsNull(repository.TotalUniqueViews);
+			}
+
+			foreach (var repository in repositories_NoStarsData)
+			{
+				Assert.IsNull(repository.StarredAt);
+				Assert.IsNotNull(repository.TotalClones);
+				Assert.IsNotNull(repository.TotalUniqueClones);
+				Assert.IsNotNull(repository.TotalViews);
+				Assert.IsNotNull(repository.TotalUniqueViews);
 			}
 
 			Assert.IsNotEmpty(repositories.SelectMany(x => x.StarredAt));
@@ -76,7 +95,7 @@ namespace GitTrends.UnitTests
 		}
 
 		[Test]
-		public async Task UpdateRepositoriesWithViewsClonesAndStarsData_ValidRepo_NotFiltered()
+		public async Task UpdateRepositoriesWithViewsClonesData_ValidRepo_NotFiltered()
 		{
 			//Arrange
 			var repositories = new List<Repository>();
@@ -105,7 +124,36 @@ namespace GitTrends.UnitTests
 		}
 
 		[Test]
-		public async Task UpdateRepositoriesWithViewsClonesAndStarsData_EmptyRepos()
+		public async Task UpdateRepositoriesWithStarsData_ValidRepo_NotFiltered()
+		{
+			//Arrange
+			var repositories = new List<Repository>();
+			var repositories_NoViewsClonesStarsData = new List<Repository>();
+
+			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
+			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
+			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
+
+			//Act
+			await foreach (var repository in gitHubGraphQLApiService.GetRepositories(gitHubUserService.Alias, CancellationToken.None).ConfigureAwait(false))
+			{
+				repositories_NoViewsClonesStarsData.Add(repository);
+			}
+
+			var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+			{
+				await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(repositories_NoViewsClonesStarsData, CancellationToken.None).ConfigureAwait(false))
+				{
+					repositories.Add(repository);
+				}
+			});
+
+			//Assert
+			Assert.IsTrue(exception?.Message.Contains("more than one matching element"));
+		}
+
+		[Test]
+		public async Task UpdateRepositoriesWithViewsClonesData_EmptyRepos()
 		{
 			//Arrange
 			var repositories = new List<Repository>();
@@ -123,12 +171,33 @@ namespace GitTrends.UnitTests
 		}
 
 		[Test]
+		public async Task UpdateRepositoriesWithViewsClonesStarsData_EmptyRepos()
+		{
+			//Arrange
+			var repositories = new List<Repository>();
+
+			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
+
+			//Act
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(new List<Repository>(), CancellationToken.None).ConfigureAwait(false))
+			{
+				repositories.Add(repository);
+			}
+
+			//Assert
+			Assert.IsEmpty(repositories);
+		}
+
+		[Test]
 		public async Task UpdateRepositoriesWithViewsClonesAndStarsData_ValidRepo_Unauthenticated()
 		{
 			//Arrange
-			IReadOnlyList<Repository> repositories_NoViewsClonesData_Filtered;
+			IReadOnlyList<Repository> repositories_NoStarsData_Filtered;
+			IReadOnlyList<Repository> repositories_NoViewsClonesStarsData_Filtered;
+
 			var repositories = new List<Repository>();
-			var repositories_NoViewsClonesData = new List<Repository>();
+			var repositories_NoStarsData = new List<Repository>();
+			var repositories_NoViewsClonesStarsData = new List<Repository>();
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
@@ -138,14 +207,21 @@ namespace GitTrends.UnitTests
 			//Act
 			await foreach (var repository in gitHubGraphQLApiService.GetRepositories(gitHubUserService.Alias, CancellationToken.None).ConfigureAwait(false))
 			{
-				repositories_NoViewsClonesData.Add(repository);
+				repositories_NoViewsClonesStarsData.Add(repository);
 			}
 
-			repositories_NoViewsClonesData_Filtered = repositories_NoViewsClonesData.RemoveForksAndDuplicates().ToList();
+			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksAndDuplicates().ToList();
 
 			gitHubUserService.InvalidateToken();
 
-			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			{
+				repositories_NoStarsData.Add(repository);
+			};
+
+			repositories_NoStarsData_Filtered = repositories_NoStarsData.RemoveForksAndDuplicates().ToList();
+
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(repositories_NoStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories.Add(repository);
 			};
@@ -160,9 +236,12 @@ namespace GitTrends.UnitTests
 		public async Task UpdateRepositoriesWithViewsClonesAndStarsData_ValidRepo_Authenticated()
 		{
 			//Arrange
-			IReadOnlyList<Repository> repositories_NoViewsClonesData_Filtered;
+			IReadOnlyList<Repository> repositories_NoStarsData_Filtered;
+			IReadOnlyList<Repository> repositories_NoViewsClonesStarsData_Filtered;
+
 			var repositories = new List<Repository>();
-			var repositories_NoViewsClonesData = new List<Repository>();
+			var repositories_NoStarsData = new List<Repository>();
+			var repositories_NoViewsClonesStarsData = new List<Repository>();
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
@@ -173,18 +252,25 @@ namespace GitTrends.UnitTests
 			//Act
 			await foreach (var repository in gitHubGraphQLApiService.GetRepositories(gitHubUserService.Alias, CancellationToken.None).ConfigureAwait(false))
 			{
-				repositories_NoViewsClonesData.Add(repository);
+				repositories_NoViewsClonesStarsData.Add(repository);
 			}
 
-			repositories_NoViewsClonesData_Filtered = repositories_NoViewsClonesData.RemoveForksAndDuplicates().ToList();
+			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksAndDuplicates().ToList();
 
-			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
+			{
+				repositories_NoStarsData.Add(repository);
+			};
+
+			repositories_NoStarsData_Filtered = repositories_NoStarsData.RemoveForksAndDuplicates().ToList();
+
+			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(repositories_NoStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories.Add(repository);
 			};
 
 			//Assert
-			Assert.AreEqual(repositories_NoViewsClonesData_Filtered.Count, repositories.Count);
+			Assert.AreEqual(repositories_NoViewsClonesStarsData_Filtered.Count, repositories.Count);
 
 			foreach (var repository in repositories)
 			{

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
@@ -201,7 +201,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<ReferringSiteModel> referringSiteModels;
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
@@ -232,7 +232,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<ReferringSiteModel> referringSiteModels;
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
@@ -259,7 +259,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<ReferringSiteModel> referringSiteModels;
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubAuthenticationService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubAuthenticationService>();
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
@@ -289,7 +289,7 @@ namespace GitTrends.UnitTests
 		{
 			// Arrange
 			var repository = new Repository(string.Empty, string.Empty, 1, string.Empty,
-												string.Empty, 1, 2, string.Empty, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												string.Empty, 1, 2, 3, string.Empty, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
@@ -306,7 +306,7 @@ namespace GitTrends.UnitTests
 			List<MobileReferringSiteModel> mobileReferringSiteModels = new();
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
@@ -348,7 +348,7 @@ namespace GitTrends.UnitTests
 			List<MobileReferringSiteModel> mobileReferringSiteModels = new();
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
@@ -386,7 +386,7 @@ namespace GitTrends.UnitTests
 			List<MobileReferringSiteModel> mobileReferringSiteModels = new();
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubAuthenticationService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubAuthenticationService>();
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
@@ -240,7 +240,7 @@ namespace GitTrends.UnitTests
 			//"Could not resolve to a Repository with the name 'zxcvbnmlkjhgfdsa1234567890/abc123321'."
 		}
 
-		[Test]
+		[Test, Ignore("Test Will Fail if Unauthenticated API Request Count has been exceeded")]
 		public async Task GetStarGazers_Unauthenticated()
 		{
 			//Arrange

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Net;
+﻿using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using GitTrends.Shared;

--- a/GitTrends.UnitTests/Tests/Services/GitHubGraphQLApiServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubGraphQLApiServiceTests.cs
@@ -141,11 +141,12 @@ namespace GitTrends.UnitTests
 			Assert.AreEqual(GitHubConstants.GitTrendsRepoOwner, gitTrendsRepository.OwnerLogin);
 			Assert.AreEqual(AuthenticatedGitHubUserAvatarUrl, gitTrendsRepository.OwnerAvatarUrl);
 
+			Assert.Greater(repositories.Sum(x => x.StarCount), 0);
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalViews));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalUniqueViews));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalClones));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalUniqueClones));
-			Assert.AreEqual(0, repositories.Sum(x => x.StarCount));
+			Assert.AreEqual(0, repositories.Sum(x => x.StarredAt?.Count));
 		}
 
 		[Test]
@@ -214,11 +215,12 @@ namespace GitTrends.UnitTests
 			Assert.GreaterOrEqual(repositories.Count, 1);
 
 
+			Assert.Greater(repositories.Sum(x => x.StarCount), 0);
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalViews));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalUniqueViews));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalClones));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalUniqueClones));
-			Assert.AreEqual(0, repositories.Sum(x => x.StarCount));
+			Assert.AreEqual(0, repositories.Sum(x => x.StarredAt?.Count));
 		}
 
 		[Test]
@@ -267,11 +269,12 @@ namespace GitTrends.UnitTests
 			Assert.IsNotEmpty(repositories);
 			Assert.Greater(repositories.Count, 0);
 
+			Assert.Greater(repositories.Sum(x => x.StarCount), 0);
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalViews));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalUniqueViews));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalClones));
 			Assert.AreEqual(0, repositories.Sum(x => x.TotalUniqueClones));
-			Assert.AreEqual(0, repositories.Sum(x => x.StarCount));
+			Assert.AreEqual(0, repositories.Sum(x => x.StarredAt?.Count));
 		}
 
 		[Test]

--- a/GitTrends.UnitTests/Tests/Services/GitHubGraphQLApiServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubGraphQLApiServiceTests.cs
@@ -380,7 +380,7 @@ namespace GitTrends.UnitTests
 
 			//Assert
 			Assert.IsNotEmpty(starGazers.StarredAt);
-			Assert.Greater(starGazers.StarredAt.Count, 400);
+			Assert.Greater(starGazers.StarredAt.Count, 500);
 			Assert.AreEqual(starGazers.TotalCount, starGazers.StarredAt.Count);
 		}
 
@@ -400,7 +400,7 @@ namespace GitTrends.UnitTests
 
 			//Assert
 			Assert.NotNull(starGazers);
-			Assert.Greater(starGazers.TotalCount, 250);
+			Assert.Greater(starGazers.TotalCount, 500);
 			Assert.IsNotEmpty(starGazers.StarredAt);
 			Assert.AreEqual(starGazers.TotalCount, starGazers.StarredAt.Count);
 		}

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests.cs
@@ -24,7 +24,7 @@ namespace GitTrends.UnitTests
 			bool didPullToRefreshFailedFire = false;
 			var pullToRefreshFailedTCS = new TaskCompletionSource<PullToRefreshFailedEventArgs>();
 
-			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0,
+			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
 				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			ReferringSitesViewModel.PullToRefreshFailed += HandlePullToRefreshFailed;
@@ -88,7 +88,7 @@ namespace GitTrends.UnitTests
 			bool isEmptyDataViewEnabled_Initial, isEmptyDataViewEnabled_DuringRefresh, isEmptyDataViewEnabled_Final;
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
-			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0,
+			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
 				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_AbuseApiLimit.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_AbuseApiLimit.cs
@@ -25,7 +25,7 @@ namespace GitTrends.UnitTests
 			bool isEmptyDataViewEnabled_Initial, isEmptyDataViewEnabled_DuringRefresh, isEmptyDataViewEnabled_Final;
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
-			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0,
+			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
 				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_MaximumApiCallLimit.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_MaximumApiCallLimit.cs
@@ -26,7 +26,7 @@ namespace GitTrends.UnitTests
 			bool isEmptyDataViewEnabled_Initial, isEmptyDataViewEnabled_DuringRefresh, isEmptyDataViewEnabled_Final;
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
-			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0,
+			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
 				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_ServerError.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_ServerError.cs
@@ -25,7 +25,7 @@ namespace GitTrends.UnitTests
 			bool isEmptyDataViewEnabled_Initial, isEmptyDataViewEnabled_DuringRefresh, isEmptyDataViewEnabled_Final;
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
-			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0,
+			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
 				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();

--- a/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
@@ -94,7 +94,7 @@ namespace GitTrends.UnitTests
 		public async Task FetchDataCommandTest_AuthenticatedUser_NoData()
 		{
 			//Arrange
-			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 			Repository repository_RepositorySavedToDatabaseResult;
 
 			TaskCompletionSource<Repository> repositorySavedToDatabaseTCS = new();

--- a/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
@@ -111,7 +111,6 @@ namespace GitTrends.UnitTests
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
-
 			await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
 
 			//Act
@@ -139,7 +138,7 @@ namespace GitTrends.UnitTests
 			Assert.IsNotEmpty(dailyClonesList_Final);
 			Assert.IsNotEmpty(dailyStarsList_Final);
 
-			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarCount, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
+			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarredAt?.Count, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
 
 			for (int i = 0; i < dailyViewsList_Final.Count; i++)
 			{

--- a/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
@@ -35,7 +35,7 @@ namespace GitTrends.UnitTests
 			await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
 
 			var repository = await gitHubGraphQLApiService.GetRepository(GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsRepoName, CancellationToken.None);
-			await foreach (var completedReposiory in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsClonesAndStarsData(new[] { repository }, CancellationToken.None).ConfigureAwait(false))
+			await foreach (var completedReposiory in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(new[] { repository }, CancellationToken.None).ConfigureAwait(false))
 			{
 				repository = completedReposiory;
 			}
@@ -209,7 +209,7 @@ namespace GitTrends.UnitTests
 
 			if (shouldIncludeViewsClonesData)
 			{
-				await foreach (var completedReposiory in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsClonesAndStarsData(new[] { repository }, CancellationToken.None).ConfigureAwait(false))
+				await foreach (var completedReposiory in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(new[] { repository }, CancellationToken.None).ConfigureAwait(false))
 				{
 					repository = completedReposiory;
 				}

--- a/GitTrends/Services/BaseMobileApiService.cs
+++ b/GitTrends/Services/BaseMobileApiService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +18,7 @@ namespace GitTrends
 
 		protected IAnalyticsService AnalyticsService { get; }
 
-		protected string GetGitHubBearerTokenHeader(GitHubToken token) => $"{token.TokenType} {token.AccessToken}";
+		protected string GetGitHubBearerTokenHeader(GitHubToken token) => token.IsEmpty() ? string.Empty : $"{token.TokenType} {token.AccessToken}";
 
 		protected async Task<T> AttemptAndRetry_Mobile<T>(Func<Task<T>> action, CancellationToken cancellationToken, int numRetries = 3, [CallerMemberName] string callerName = "")
 		{

--- a/GitTrends/Services/GitHubApiRepositoriesService.cs
+++ b/GitTrends/Services/GitHubApiRepositoriesService.cs
@@ -131,7 +131,7 @@ namespace GitTrends
 
 		async Task<(RepositoryViewsResponseModel? ViewsResponse, RepositoryClonesResponseModel? ClonesResponse, StarGazers? StarGazerResponse)> GetRepositoryStatistics(Repository repository, CancellationToken cancellationToken)
 		{
-			var getStarGazrsTask = _gitHubGraphQLApiService.GetStarGazers(repository.Name, repository.OwnerLogin, cancellationToken);
+			var getStarGazrsTask = _gitHubApiV3Service.GetStarGazers(repository.Name, repository.OwnerLogin, cancellationToken);
 			var getViewStatisticsTask = _gitHubApiV3Service.GetRepositoryViewStatistics(repository.OwnerLogin, repository.Name, cancellationToken);
 			var getCloneStatisticsTask = _gitHubApiV3Service.GetRepositoryCloneStatistics(repository.OwnerLogin, repository.Name, cancellationToken);
 

--- a/GitTrends/Services/GitHubApiV3Service.cs
+++ b/GitTrends/Services/GitHubApiV3Service.cs
@@ -128,7 +128,7 @@ namespace GitTrends
 			}
 		}
 
-		public async Task<StarGazers> GetStarGazers(string owner, string repo, CancellationToken cancellationToken)
+		public async Task<StarGazers> GetStarGazers(string owner, string repo, CancellationToken cancellationToken, int starGazersPerRequest = 100)
 		{
 			if (_gitHubUserService.IsDemoUser)
 			{
@@ -146,7 +146,7 @@ namespace GitTrends
 				do
 				{
 					var token = await _gitHubUserService.GetGitHubToken().ConfigureAwait(false);
-					starGazerResponse = await AttemptAndRetry_Mobile(() => _githubApiClient.GetStarGazers(owner, repo, currentPageNumber, GetGitHubBearerTokenHeader(token)), cancellationToken).ConfigureAwait(false);
+					starGazerResponse = await AttemptAndRetry_Mobile(() => _githubApiClient.GetStarGazers(owner, repo, currentPageNumber, GetGitHubBearerTokenHeader(token), starGazersPerRequest), cancellationToken).ConfigureAwait(false);
 
 					totalStarGazers.AddRange(starGazerResponse);
 					currentPageNumber++;

--- a/GitTrends/Services/GitHubApiV3Service.cs
+++ b/GitTrends/Services/GitHubApiV3Service.cs
@@ -127,5 +127,23 @@ namespace GitTrends
 				return referringSites;
 			}
 		}
+
+		public async Task<StarGazers> GetStarGazers(string owner, string repo, CancellationToken cancellationToken)
+		{
+			if (_gitHubUserService.IsDemoUser)
+			{
+				var starCount = DemoDataConstants.GetRandomNumber();
+				var starredAtDates = DemoDataConstants.GenerateStarredAtDates(starCount);
+
+				return new StarGazers(starCount, starredAtDates.Select(x => new StarGazerInfo(x, string.Empty)));
+			}
+			else
+			{
+				var token = await _gitHubUserService.GetGitHubToken().ConfigureAwait(false);
+				var starGazers = await AttemptAndRetry_Mobile(() => _githubApiClient.GetStarGazers(owner, repo, GetGitHubBearerTokenHeader(token)), cancellationToken).ConfigureAwait(false);
+
+				return new StarGazers(starGazers.Count, starGazers.Select(x => new StarGazerInfo(x.StarredAt, string.Empty)));
+			}
+		}
 	}
 }

--- a/GitTrends/Services/GitHubGraphQLApiService.cs
+++ b/GitTrends/Services/GitHubGraphQLApiService.cs
@@ -67,6 +67,7 @@ namespace GitTrends
 									repositoryResult.Repository.Owner.AvatarUrl,
 									repositoryResult.Repository.Issues.IssuesCount,
 									repositoryResult.Repository.Watchers.TotalCount,
+									starGazersResult.StarredAt.Count,
 									repositoryResult.Repository.Url.ToString(),
 									repositoryResult.Repository.IsFork,
 									DateTimeOffset.UtcNow,
@@ -109,7 +110,7 @@ namespace GitTrends
 				{
 					var demoRepo = new Repository($"Repository " + DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomNumber(),
 												DemoUserConstants.Alias, _gitHubUserService.AvatarUrl, DemoDataConstants.GetRandomNumber(), DemoDataConstants.GetRandomNumber(),
-												_gitHubUserService.AvatarUrl, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												DemoDataConstants.GetRandomNumber(), _gitHubUserService.AvatarUrl, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
 					yield return demoRepo;
 				}
 
@@ -176,7 +177,7 @@ namespace GitTrends
 					{
 						if (repository is not null)
 							repositoryList.Add(new Repository(repository.Name, repository.Description, repository.ForkCount, repository.Owner.Login, repository.Owner.AvatarUrl,
-														repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission));
+														repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Stargazers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission));
 					}
 				}
 				while (repositoryConnection?.PageInfo?.HasNextPage is true);
@@ -221,7 +222,7 @@ namespace GitTrends
 				{
 					if (repository is not null)
 						yield return new Repository(repository.Name, repository.Description, repository.ForkCount, repository.Owner.Login, repository.Owner.AvatarUrl,
-													repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission);
+													repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Stargazers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission);
 				}
 			}
 			while (repositoryConnection?.PageInfo?.HasNextPage is true);

--- a/GitTrends/Services/NotificationService.cs
+++ b/GitTrends/Services/NotificationService.cs
@@ -280,7 +280,7 @@ namespace GitTrends
 					//Create repository with only Name & Owner, because those are the only metrics that TrendsPage needs to fetch the chart data
 					var repository = new Repository(MostRecentTrendingRepositoryName, string.Empty, 0,
 													MostRecentTrendingRepositoryOwner, string.Empty,
-													0, 0, string.Empty, false, default, RepositoryPermission.UNKNOWN);
+													0, 0, 0, string.Empty, false, default, RepositoryPermission.UNKNOWN);
 
 					await _deepLinkingService.NavigateToTrendsPage(repository).ConfigureAwait(false);
 				}

--- a/GitTrends/ViewModels/TrendsViewModel.cs
+++ b/GitTrends/ViewModels/TrendsViewModel.cs
@@ -333,7 +333,7 @@ namespace GitTrends
 			}
 			catch (Exception e) when (_gitHubApiStatusService.IsAbuseRateLimit(e, out var retryTimeSpan))
 			{
-				_backgroundFetchService.TryScheduleRetryRepositoriesViewsClones(repository, retryTimeSpan.Value);
+				_backgroundFetchService.TryScheduleRetryRepositoriesViewsClonesStars(repository, retryTimeSpan.Value);
 
 				var repositoryFromDatabase = await _repositoryDatabase.GetRepository(repository.Url).ConfigureAwait(false);
 

--- a/GitTrends/ViewModels/TrendsViewModel.cs
+++ b/GitTrends/ViewModels/TrendsViewModel.cs
@@ -272,12 +272,12 @@ namespace GitTrends
 
 			try
 			{
-				if (repository.ContainsTrafficData
+				if (repository.ContainsViewsClonesStarsData
 					&& repository.DataDownloadedAt > DateTimeOffset.Now.AddDays(-1))
 				{
-					repositoryStars = repository.StarredAt ?? throw new InvalidOperationException($"{nameof(Repository.StarredAt)} cannot be null when {nameof(Repository.ContainsTrafficData)} is true");
-					repositoryViews = repository.DailyViewsList ?? throw new InvalidOperationException($"{nameof(Repository.DailyViewsList)} cannot be null when {nameof(Repository.ContainsTrafficData)} is true");
-					repositoryClones = repository.DailyClonesList ?? throw new InvalidOperationException($"{nameof(Repository.DailyClonesList)} cannot be null when {nameof(Repository.ContainsTrafficData)} is true");
+					repositoryStars = repository.StarredAt ?? throw new InvalidOperationException($"{nameof(Repository.StarredAt)} cannot be null when {nameof(Repository.ContainsViewsClonesStarsData)} is true");
+					repositoryViews = repository.DailyViewsList ?? throw new InvalidOperationException($"{nameof(Repository.DailyViewsList)} cannot be null when {nameof(Repository.ContainsViewsClonesStarsData)} is true");
+					repositoryClones = repository.DailyClonesList ?? throw new InvalidOperationException($"{nameof(Repository.DailyClonesList)} cannot be null when {nameof(Repository.ContainsViewsClonesStarsData)} is true");
 				}
 				else
 				{

--- a/GitTrends/Views/Repository/RepositoryDataTemplateSelector.cs
+++ b/GitTrends/Views/Repository/RepositoryDataTemplateSelector.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using GitTrends.Mobile.Common;
 using GitTrends.Shared;


### PR DESCRIPTION
This PR optimizes how GitTrends handles retrieving StarGazer queries from the GitHub API.

Because the GitHub API limits StarGazer requests to 100 per response, a repository with, for example, 14K Stars will require 140 round-trips from GitTrends to the GitHub API. 

Because the StarGazer data is not required for the Repository Page, it is now deferred to the `BackgroundFetchService`.