### PR TITLE
Optimize TrendsViewModel

### DIFF
--- a/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
@@ -14,6 +14,21 @@ namespace GitTrends.UnitTests
 	class BackgroundFetchServiceTests : BaseTest
 	{
 		[Test]
+		public void VerifyIdentifiers()
+		{
+			// Assert
+			const string organizationName = "GitTrends";
+			var repository = CreateRepository(false);
+			var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
+
+			// Assert
+			Assert.AreEqual($"{backgroundFetchService.RetryGetReferringSitesIdentifier}.{repository.Url}", backgroundFetchService.GetRetryGetReferringSitesIdentifier(repository));
+			Assert.AreEqual($"{backgroundFetchService.RetryRepositoriesStarsIdentifier}.{repository.Url}", backgroundFetchService.GetRetryRepositoriesStarsIdentifier(repository));
+			Assert.AreEqual($"{backgroundFetchService.RetryOrganizationsReopsitoriesIdentifier}.{organizationName}", backgroundFetchService.GetRetryOrganizationsRepositoriesIdentifier(organizationName));
+			Assert.AreEqual($"{backgroundFetchService.RetryRepositoriesViewsClonesStarsIdentifier}.{repository.Url}", backgroundFetchService.GetRetryRepositoriesViewsClonesStarsIdentifier(repository));
+		}
+
+		[Test]
 		public async Task ScheduleRetryRepositoriesViewsClonesStarsTest_AuthenticatedUser()
 		{
 			//Arrange

--- a/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
@@ -72,15 +72,15 @@ namespace GitTrends.UnitTests
 			for (int i = 0; i < dailyViewsList_Final.Count; i++)
 			{
 				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].LocalDay, dailyViewsList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
 				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalViews, dailyViewsList_Final[i].TotalViews);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
 			}
 
 			for (int i = 0; i < dailyClonesList_Final.Count; i++)
 			{
 				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].LocalDay, dailyClonesList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
 				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalClones, dailyClonesList_Final[i].TotalClones);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
 			}
 
 			void HandleRepositorySavedToDatabase(object? sender, Repository e)
@@ -126,6 +126,162 @@ namespace GitTrends.UnitTests
 			dailyClonesList_Final = trendsViewModel.DailyClonesList;
 
 			//Assert
+			Assert.IsNull(repository_Initial.DailyClonesList);
+			Assert.IsNull(repository_Initial.DailyViewsList);
+			Assert.IsNull(repository_Initial.StarredAt);
+
+			Assert.IsEmpty(dailyViewsList_Initial);
+			Assert.IsEmpty(dailyClonesList_Initial);
+			Assert.IsEmpty(dailyStarsList_Initial);
+
+			Assert.IsNotEmpty(dailyViewsList_Final);
+			Assert.IsNotEmpty(dailyClonesList_Final);
+			Assert.IsNotEmpty(dailyStarsList_Final);
+
+			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarredAt?.Count, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
+
+			for (int i = 0; i < dailyViewsList_Final.Count; i++)
+			{
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].LocalDay, dailyViewsList_Final[i].LocalDay);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalViews, dailyViewsList_Final[i].TotalViews);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
+			}
+
+			for (int i = 0; i < dailyClonesList_Final.Count; i++)
+			{
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].LocalDay, dailyClonesList_Final[i].LocalDay);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalClones, dailyClonesList_Final[i].TotalClones);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
+			}
+
+			void HandleRepositorySavedToDatabase(object? sender, Repository e)
+			{
+				TrendsViewModel.RepositorySavedToDatabase -= HandleRepositorySavedToDatabase;
+				repositorySavedToDatabaseTCS.SetResult(e);
+			}
+		}
+
+		[Test]
+		public async Task FetchDataCommandTest_AuthenticatedUser_NoData_FetchingViewsStarsDataInBackground()
+		{
+			//Arrange
+			bool wasTryScheduleRetryRepositoriesStarsSuccessful;
+
+			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+			Repository repository_RepositorySavedToDatabaseResult;
+
+			TaskCompletionSource<Repository> repositorySavedToDatabaseTCS = new();
+
+			TrendsViewModel.RepositorySavedToDatabase += HandleRepositorySavedToDatabase;
+
+			IReadOnlyList<DailyStarsModel> dailyStarsList_Initial, dailyStarsList_Final;
+			IReadOnlyList<DailyViewsModel> dailyViewsList_Initial, dailyViewsList_Final;
+			IReadOnlyList<DailyClonesModel> dailyClonesList_Initial, dailyClonesList_Final;
+
+			var trendsViewModel = ServiceCollection.ServiceProvider.GetRequiredService<TrendsViewModel>();
+
+			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
+			var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
+			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
+			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
+
+			await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
+
+			//Act
+			dailyStarsList_Initial = trendsViewModel.DailyStarsList;
+			dailyViewsList_Initial = trendsViewModel.DailyViewsList;
+			dailyClonesList_Initial = trendsViewModel.DailyClonesList;
+
+			wasTryScheduleRetryRepositoriesStarsSuccessful = backgroundFetchService.TryScheduleRetryRepositoriesStars(repository_Initial);
+
+			await trendsViewModel.FetchDataCommand.ExecuteAsync((repository_Initial, CancellationToken.None)).ConfigureAwait(false);
+			repository_RepositorySavedToDatabaseResult = await repositorySavedToDatabaseTCS.Task.ConfigureAwait(false);
+
+			dailyStarsList_Final = trendsViewModel.DailyStarsList;
+			dailyViewsList_Final = trendsViewModel.DailyViewsList;
+			dailyClonesList_Final = trendsViewModel.DailyClonesList;
+
+			//Assert
+			Assert.IsTrue(wasTryScheduleRetryRepositoriesStarsSuccessful);
+
+			Assert.IsNull(repository_Initial.DailyClonesList);
+			Assert.IsNull(repository_Initial.DailyViewsList);
+			Assert.IsNull(repository_Initial.StarredAt);
+
+			Assert.IsEmpty(dailyViewsList_Initial);
+			Assert.IsEmpty(dailyClonesList_Initial);
+			Assert.IsEmpty(dailyStarsList_Initial);
+
+			Assert.IsNotEmpty(dailyViewsList_Final);
+			Assert.IsNotEmpty(dailyClonesList_Final);
+			Assert.IsNotEmpty(dailyStarsList_Final);
+
+			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarredAt?.Count, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
+
+			for (int i = 0; i < dailyViewsList_Final.Count; i++)
+			{
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].LocalDay, dailyViewsList_Final[i].LocalDay);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalViews, dailyViewsList_Final[i].TotalViews);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
+			}
+
+			for (int i = 0; i < dailyClonesList_Final.Count; i++)
+			{
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].LocalDay, dailyClonesList_Final[i].LocalDay);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalClones, dailyClonesList_Final[i].TotalClones);
+				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
+			}
+
+			void HandleRepositorySavedToDatabase(object? sender, Repository e)
+			{
+				TrendsViewModel.RepositorySavedToDatabase -= HandleRepositorySavedToDatabase;
+				repositorySavedToDatabaseTCS.SetResult(e);
+			}
+		}
+
+		[Test]
+		public async Task FetchDataCommandTest_AuthenticatedUser_NoData_FetchingViewsClonesStarsDataInBackground()
+		{
+			//Arrange
+			bool wasTryScheduleRetryRepositoriesViewsClonesStarsSuccessful;
+
+			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+			Repository repository_RepositorySavedToDatabaseResult;
+
+			TaskCompletionSource<Repository> repositorySavedToDatabaseTCS = new();
+
+			TrendsViewModel.RepositorySavedToDatabase += HandleRepositorySavedToDatabase;
+
+			IReadOnlyList<DailyStarsModel> dailyStarsList_Initial, dailyStarsList_Final;
+			IReadOnlyList<DailyViewsModel> dailyViewsList_Initial, dailyViewsList_Final;
+			IReadOnlyList<DailyClonesModel> dailyClonesList_Initial, dailyClonesList_Final;
+
+			var trendsViewModel = ServiceCollection.ServiceProvider.GetRequiredService<TrendsViewModel>();
+
+			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
+			var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
+			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
+			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
+
+			await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
+
+			//Act
+			dailyStarsList_Initial = trendsViewModel.DailyStarsList;
+			dailyViewsList_Initial = trendsViewModel.DailyViewsList;
+			dailyClonesList_Initial = trendsViewModel.DailyClonesList;
+
+			wasTryScheduleRetryRepositoriesViewsClonesStarsSuccessful = backgroundFetchService.TryScheduleRetryRepositoriesViewsClonesStars(repository_Initial);
+
+			await trendsViewModel.FetchDataCommand.ExecuteAsync((repository_Initial, CancellationToken.None)).ConfigureAwait(false);
+			repository_RepositorySavedToDatabaseResult = await repositorySavedToDatabaseTCS.Task.ConfigureAwait(false);
+
+			dailyStarsList_Final = trendsViewModel.DailyStarsList;
+			dailyViewsList_Final = trendsViewModel.DailyViewsList;
+			dailyClonesList_Final = trendsViewModel.DailyClonesList;
+
+			//Assert
+			Assert.IsTrue(wasTryScheduleRetryRepositoriesViewsClonesStarsSuccessful);
+
 			Assert.IsNull(repository_Initial.DailyClonesList);
 			Assert.IsNull(repository_Initial.DailyViewsList);
 			Assert.IsNull(repository_Initial.StarredAt);

--- a/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
@@ -166,77 +166,22 @@ namespace GitTrends.UnitTests
 		{
 			//Arrange
 			bool wasTryScheduleRetryRepositoriesStarsSuccessful;
-
 			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
-			Repository repository_RepositorySavedToDatabaseResult;
-
-			TaskCompletionSource<Repository> repositorySavedToDatabaseTCS = new();
-
-			TrendsViewModel.RepositorySavedToDatabase += HandleRepositorySavedToDatabase;
-
-			IReadOnlyList<DailyStarsModel> dailyStarsList_Initial, dailyStarsList_Final;
-			IReadOnlyList<DailyViewsModel> dailyViewsList_Initial, dailyViewsList_Final;
-			IReadOnlyList<DailyClonesModel> dailyClonesList_Initial, dailyClonesList_Final;
-
-			var trendsViewModel = ServiceCollection.ServiceProvider.GetRequiredService<TrendsViewModel>();
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
-			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
 			await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
 
 			//Act
-			dailyStarsList_Initial = trendsViewModel.DailyStarsList;
-			dailyViewsList_Initial = trendsViewModel.DailyViewsList;
-			dailyClonesList_Initial = trendsViewModel.DailyClonesList;
 
 			wasTryScheduleRetryRepositoriesStarsSuccessful = backgroundFetchService.TryScheduleRetryRepositoriesStars(repository_Initial);
 
-			await trendsViewModel.FetchDataCommand.ExecuteAsync((repository_Initial, CancellationToken.None)).ConfigureAwait(false);
-			repository_RepositorySavedToDatabaseResult = await repositorySavedToDatabaseTCS.Task.ConfigureAwait(false);
-
-			dailyStarsList_Final = trendsViewModel.DailyStarsList;
-			dailyViewsList_Final = trendsViewModel.DailyViewsList;
-			dailyClonesList_Final = trendsViewModel.DailyClonesList;
+			await FetchDataCommandTest_AuthenticatedUser_NoData();
 
 			//Assert
 			Assert.IsTrue(wasTryScheduleRetryRepositoriesStarsSuccessful);
-
-			Assert.IsNull(repository_Initial.DailyClonesList);
-			Assert.IsNull(repository_Initial.DailyViewsList);
-			Assert.IsNull(repository_Initial.StarredAt);
-
-			Assert.IsEmpty(dailyViewsList_Initial);
-			Assert.IsEmpty(dailyClonesList_Initial);
-			Assert.IsEmpty(dailyStarsList_Initial);
-
-			Assert.IsNotEmpty(dailyViewsList_Final);
-			Assert.IsNotEmpty(dailyClonesList_Final);
-			Assert.IsNotEmpty(dailyStarsList_Final);
-
-			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarredAt?.Count, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
-
-			for (int i = 0; i < dailyViewsList_Final.Count; i++)
-			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].LocalDay, dailyViewsList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalViews, dailyViewsList_Final[i].TotalViews);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
-			}
-
-			for (int i = 0; i < dailyClonesList_Final.Count; i++)
-			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].LocalDay, dailyClonesList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalClones, dailyClonesList_Final[i].TotalClones);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
-			}
-
-			void HandleRepositorySavedToDatabase(object? sender, Repository e)
-			{
-				TrendsViewModel.RepositorySavedToDatabase -= HandleRepositorySavedToDatabase;
-				repositorySavedToDatabaseTCS.SetResult(e);
-			}
 		}
 
 		[Test]
@@ -244,77 +189,22 @@ namespace GitTrends.UnitTests
 		{
 			//Arrange
 			bool wasTryScheduleRetryRepositoriesViewsClonesStarsSuccessful;
-
 			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
-			Repository repository_RepositorySavedToDatabaseResult;
-
-			TaskCompletionSource<Repository> repositorySavedToDatabaseTCS = new();
-
-			TrendsViewModel.RepositorySavedToDatabase += HandleRepositorySavedToDatabase;
-
-			IReadOnlyList<DailyStarsModel> dailyStarsList_Initial, dailyStarsList_Final;
-			IReadOnlyList<DailyViewsModel> dailyViewsList_Initial, dailyViewsList_Final;
-			IReadOnlyList<DailyClonesModel> dailyClonesList_Initial, dailyClonesList_Final;
-
-			var trendsViewModel = ServiceCollection.ServiceProvider.GetRequiredService<TrendsViewModel>();
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
-			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
 			await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
 
 			//Act
-			dailyStarsList_Initial = trendsViewModel.DailyStarsList;
-			dailyViewsList_Initial = trendsViewModel.DailyViewsList;
-			dailyClonesList_Initial = trendsViewModel.DailyClonesList;
 
 			wasTryScheduleRetryRepositoriesViewsClonesStarsSuccessful = backgroundFetchService.TryScheduleRetryRepositoriesViewsClonesStars(repository_Initial);
 
-			await trendsViewModel.FetchDataCommand.ExecuteAsync((repository_Initial, CancellationToken.None)).ConfigureAwait(false);
-			repository_RepositorySavedToDatabaseResult = await repositorySavedToDatabaseTCS.Task.ConfigureAwait(false);
-
-			dailyStarsList_Final = trendsViewModel.DailyStarsList;
-			dailyViewsList_Final = trendsViewModel.DailyViewsList;
-			dailyClonesList_Final = trendsViewModel.DailyClonesList;
+			await FetchDataCommandTest_AuthenticatedUser_NoData();
 
 			//Assert
 			Assert.IsTrue(wasTryScheduleRetryRepositoriesViewsClonesStarsSuccessful);
-
-			Assert.IsNull(repository_Initial.DailyClonesList);
-			Assert.IsNull(repository_Initial.DailyViewsList);
-			Assert.IsNull(repository_Initial.StarredAt);
-
-			Assert.IsEmpty(dailyViewsList_Initial);
-			Assert.IsEmpty(dailyClonesList_Initial);
-			Assert.IsEmpty(dailyStarsList_Initial);
-
-			Assert.IsNotEmpty(dailyViewsList_Final);
-			Assert.IsNotEmpty(dailyClonesList_Final);
-			Assert.IsNotEmpty(dailyStarsList_Final);
-
-			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarredAt?.Count, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
-
-			for (int i = 0; i < dailyViewsList_Final.Count; i++)
-			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].LocalDay, dailyViewsList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalViews, dailyViewsList_Final[i].TotalViews);
-			}
-
-			for (int i = 0; i < dailyClonesList_Final.Count; i++)
-			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].LocalDay, dailyClonesList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalClones, dailyClonesList_Final[i].TotalClones);
-			}
-
-			void HandleRepositorySavedToDatabase(object? sender, Repository e)
-			{
-				TrendsViewModel.RepositorySavedToDatabase -= HandleRepositorySavedToDatabase;
-				repositorySavedToDatabaseTCS.SetResult(e);
-			}
 		}
 
 		[TestCase(true)]

--- a/GitTrends/Constants/CachedDataConstants.cs
+++ b/GitTrends/Constants/CachedDataConstants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace GitTrends
+{
+	public static class CachedDataConstants
+	{
+		public static TimeSpan StarsDataCacheLifeSpan { get; } = TimeSpan.FromHours(6);
+		public static TimeSpan ViewsClonesCacheLifeSpan { get; } = TimeSpan.FromHours(1);
+		public static TimeSpan DatbaseRepositoryLifeSpan { get; } = TimeSpan.FromDays(14);
+		public static TimeSpan DatabaseReferringSitesLifeSpan { get; } = TimeSpan.FromDays(30);
+	}
+}
+

--- a/GitTrends/Database/ReferringSitesDatabase.cs
+++ b/GitTrends/Database/ReferringSitesDatabase.cs
@@ -11,7 +11,7 @@ namespace GitTrends
 {
 	public class ReferringSitesDatabase : BaseDatabase
 	{
-		public ReferringSitesDatabase(IFileSystem fileSystem, IAnalyticsService analyticsService) : base(fileSystem, analyticsService, TimeSpan.FromDays(30))
+		public ReferringSitesDatabase(IFileSystem fileSystem, IAnalyticsService analyticsService) : base(fileSystem, analyticsService, CachedDataConstants.DatabaseReferringSitesLifeSpan)
 		{
 
 		}

--- a/GitTrends/Database/RepositoryDatabase.cs
+++ b/GitTrends/Database/RepositoryDatabase.cs
@@ -10,7 +10,7 @@ namespace GitTrends
 {
 	public class RepositoryDatabase : BaseDatabase
 	{
-		public RepositoryDatabase(IFileSystem fileSystem, IAnalyticsService analyticsService) : base(fileSystem, analyticsService, TimeSpan.FromDays(14))
+		public RepositoryDatabase(IFileSystem fileSystem, IAnalyticsService analyticsService) : base(fileSystem, analyticsService, CachedDataConstants.DatbaseRepositoryLifeSpan)
 		{
 			GitHubApiRepositoriesService.RepositoryUriNotFound += HandleRepositoryUriNotFound;
 		}

--- a/GitTrends/Services/BackgroundFetchService.cs
+++ b/GitTrends/Services/BackgroundFetchService.cs
@@ -193,6 +193,11 @@ namespace GitTrends
 			}
 		}
 
+		public string GetRetryGetReferringSitesIdentifier(Repository repository) => $"{RetryGetReferringSitesIdentifier}.{repository.Url}";
+		public string GetRetryRepositoriesStarsIdentifier(Repository repository) => $"{RetryRepositoriesStarsIdentifier}.{repository.Url}";
+		public string GetRetryRepositoriesViewsClonesStarsIdentifier(Repository repository) => $"{RetryRepositoriesViewsClonesStarsIdentifier}.{repository.Url}";
+		public string GetRetryOrganizationsRepositoriesIdentifier(string organizationName) => $"{RetryOrganizationsReopsitoriesIdentifier}.{organizationName}";
+
 		void ScheduleRetryOrganizationsRepositories(string organizationName, TimeSpan? delay)
 		{
 			_queuedJobs.Add(GetRetryOrganizationsRepositoriesIdentifier(organizationName));
@@ -369,11 +374,6 @@ namespace GitTrends
 				}
 			});
 		}
-
-		string GetRetryGetReferringSitesIdentifier(Repository repository) => $"{RetryGetReferringSitesIdentifier}.{repository.Url}";
-		string GetRetryRepositoriesStarsIdentifier(Repository repository) => $"{RetryRepositoriesStarsIdentifier}.{repository.Url}";
-		string GetRetryRepositoriesViewsClonesStarsIdentifier(Repository repository) => $"{RetryRepositoriesViewsClonesStarsIdentifier}.{repository.Url}";
-		string GetRetryOrganizationsRepositoriesIdentifier(string organizationName) => $"{RetryOrganizationsReopsitoriesIdentifier}.{organizationName}";
 
 		async Task<IReadOnlyList<Repository>> GetTrendingRepositories(CancellationToken cancellationToken)
 		{

--- a/GitTrends/ViewModels/RepositoryViewModel.cs
+++ b/GitTrends/ViewModels/RepositoryViewModel.cs
@@ -218,7 +218,7 @@ namespace GitTrends
 				repositoriesFromDatabase = await repositoriesFromDatabaseTask.ConfigureAwait(false);
 
 				var repositoriesFromDatabaseThatDontRequireUpdating = repositoriesFromDatabase.Where(x => x.ContainsViewsClonesData // Ensure the repository contains data for Views + Clones
-																											&& x.DataDownloadedAt >= DateTimeOffset.Now.Subtract(TimeSpan.FromHours(12)) // Cached repositories that have been updated in the past 12 hours				
+																											&& x.DataDownloadedAt >= DateTimeOffset.Now.Subtract(CachedDataConstants.ViewsClonesCacheLifeSpan) // Cached repositories that have been updated in the past 12 hours				
 																											&& _repositoryList.Any(y => y.Url == x.Url)); // Ensure was retrieved from GitHub)
 
 				AddRepositoriesToCollection(repositoriesFromDatabaseThatDontRequireUpdating, _searchBarText, duplicateRepositoryPriorityFilter: x => x.ContainsViewsClonesData);
@@ -249,7 +249,7 @@ namespace GitTrends
 				// The StarGazer data can be gathered in the background because the data only appears if the user navigates to the StarsTrendsPage
 				// The data is gathered in the background to optimize the Pull-To-Refresh time visible to the user
 				repositoriesFromDatabaseThatDontRequireUpdating = repositoriesFromDatabase.Where(x => x.ContainsViewsClonesStarsData // Ensure the repository contains data for Views + Clones + Stars
-																											&& x.DataDownloadedAt >= DateTimeOffset.Now.Subtract(TimeSpan.FromHours(12)) // Cached repositories that have been updated in the past 12 hours				
+																											&& x.DataDownloadedAt >= DateTimeOffset.Now.Subtract(CachedDataConstants.StarsDataCacheLifeSpan) // Cached repositories that have been updated in the past 12 hours				
 																											&& _repositoryList.Any(y => y.Url == x.Url)); // Ensure was retrieved from GitHub)
 
 				AddRepositoriesToCollection(repositoriesFromDatabaseThatDontRequireUpdating, _searchBarText, duplicateRepositoryPriorityFilter: x => x.ContainsViewsClonesStarsData);

--- a/GitTrends/ViewModels/TrendsViewModel.cs
+++ b/GitTrends/ViewModels/TrendsViewModel.cs
@@ -273,14 +273,14 @@ namespace GitTrends
 			try
 			{
 				if (repository.ContainsViewsClonesData
-					&& repository.DataDownloadedAt > DateTimeOffset.Now.Add(CachedDataConstants.ViewsClonesCacheLifeSpan))
+					&& repository.DataDownloadedAt > DateTimeOffset.Now.Subtract(CachedDataConstants.ViewsClonesCacheLifeSpan))
 				{
 					repositoryViews = repository.DailyViewsList ?? throw new InvalidOperationException($"{nameof(Repository.DailyViewsList)} cannot be null when {nameof(Repository.ContainsViewsClonesStarsData)} is true");
 					repositoryClones = repository.DailyClonesList ?? throw new InvalidOperationException($"{nameof(Repository.DailyClonesList)} cannot be null when {nameof(Repository.ContainsViewsClonesStarsData)} is true");
 				}
 
 				if (repository.ContainsViewsClonesStarsData
-					&& repository.DataDownloadedAt > DateTimeOffset.Now.Add(CachedDataConstants.StarsDataCacheLifeSpan))
+					&& repository.DataDownloadedAt > DateTimeOffset.Now.Subtract(CachedDataConstants.StarsDataCacheLifeSpan))
 				{
 					repositoryStars = repository.StarredAt ?? throw new InvalidOperationException($"{nameof(Repository.StarredAt)} cannot be null when {nameof(Repository.ContainsViewsClonesStarsData)} is true");
 				}

--- a/GitTrends/ViewModels/TrendsViewModel.cs
+++ b/GitTrends/ViewModels/TrendsViewModel.cs
@@ -289,14 +289,14 @@ namespace GitTrends
 				{
 					IsFetchingData = true;
 
-					var getGetStarsDataTasj = repositoryStars is null ? GetStarsData(repository, cancellationToken) : Task.FromResult(repositoryStars);
+					var getGetStarsDataTask = repositoryStars is null ? GetStarsData(repository, cancellationToken) : Task.FromResult(repositoryStars);
 					var getViewsClonesDataTask = repositoryViews is null || repositoryClones is null
 													? GetViewsClonesData(repository, cancellationToken)
 													: Task.FromResult((repositoryViews, repositoryClones));
 
-					await Task.WhenAll(getGetStarsDataTasj, getViewsClonesDataTask).ConfigureAwait(false);
+					await Task.WhenAll(getGetStarsDataTask, getViewsClonesDataTask).ConfigureAwait(false);
 
-					repositoryStars = await getGetStarsDataTasj.ConfigureAwait(false);
+					repositoryStars = await getGetStarsDataTask.ConfigureAwait(false);
 					(repositoryViews, repositoryClones) = await getViewsClonesDataTask.ConfigureAwait(false);
 
 					var updatedRepository = repository with

--- a/GitTrends/Views/Trends/StarsStatisticsGrid.cs
+++ b/GitTrends/Views/Trends/StarsStatisticsGrid.cs
@@ -43,6 +43,7 @@ namespace GitTrends
 			Children.Add(new StarsStatisticsLabel(48) { AutomationId = TrendsPageAutomationIds.StarsStatisticsLabel }
 							.Row(Row.Stars).Column(Column.Text)
 							.CenterExpand()
+							.Bind(IsVisibleProperty, nameof(TrendsViewModel.IsStarsChartVisible))
 							.Bind<Label, double, string>(Label.TextProperty, nameof(TrendsViewModel.TotalStars), convert: totalStars => totalStars.ToAbbreviatedText()));
 
 			Children.Add(new StarSvg()
@@ -50,6 +51,7 @@ namespace GitTrends
 
 			Children.Add(new StarsStatisticsLabel(_textSize) { AutomationId = TrendsPageAutomationIds.StarsHeaderMessageLabel }
 							.Row(Row.Message).ColumnSpan(All<Column>())
+							.Bind(IsVisibleProperty, nameof(TrendsViewModel.IsStarsChartVisible))
 							.Bind(Label.TextProperty, nameof(TrendsViewModel.StarsHeaderMessageText)));
 
 			Children.Add(new SeparatorLine()


### PR DESCRIPTION
This PR optimizes `TrendsViewModel` to avoid duplicating the Background Task of fetching Stars, Views and Clones Data