### PR TITLE
Create `VideoPlayerWithLoadingIndicatorView`

### DIFF
--- a/GitTrends.Android/CustomRenderers/VideoPlayerViewCustomRenderer.cs
+++ b/GitTrends.Android/CustomRenderers/VideoPlayerViewCustomRenderer.cs
@@ -66,7 +66,7 @@ namespace GitTrends.Droid
         {
             base.OnElementPropertyChanged(sender, e);
 
-            if (e.PropertyName == Element.UrlProperty.PropertyName
+            if (e.PropertyName == VideoPlayerView.UrlProperty.PropertyName
                 && Element.Url is not null
                 && Uri.Parse(Element.Url) is Uri uri)
             {

--- a/GitTrends/Pages/Onboarding/ChartOnboardingPage.cs
+++ b/GitTrends/Pages/Onboarding/ChartOnboardingPage.cs
@@ -29,7 +29,7 @@ namespace GitTrends
 			Border = new Border { Color = Color.FromHex("E0E0E0") },
 			BackgroundColor = Color.White,
 			Padding = new Thickness(5),
-			Content = new VideoPlayerView(MediaElementService.OnboardingChartUrl)
+			Content = new VideoPlayerWithLoadingIndicatorView(MediaElementService.OnboardingChartUrl)
 		};
 
 		protected override TitleLabel CreateDescriptionTitleLabel() => new TitleLabel(OnboardingConstants.ChartPage_Title);

--- a/GitTrends/Views/Base/VideoPlayerView.cs
+++ b/GitTrends/Views/Base/VideoPlayerView.cs
@@ -6,7 +6,7 @@ namespace GitTrends
 	//On Android, use Custom Renderer for ExoPlayer because Xamarin.Forms.MediaElement uses Android.VideoView
 	public class VideoPlayerView : View
 	{
-		public readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(VideoPlayerView));
+		public static readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(VideoPlayerView));
 
 		public VideoPlayerView(string? uri)
 		{

--- a/GitTrends/Views/Base/VideoPlayerWithLoadingIndicatorView.cs
+++ b/GitTrends/Views/Base/VideoPlayerWithLoadingIndicatorView.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Xamarin.CommunityToolkit.Markup;
+using Xamarin.Forms;
+using static Xamarin.CommunityToolkit.Markup.GridRowsColumns;
+
+namespace GitTrends
+{
+	public class VideoPlayerWithLoadingIndicatorView : Grid
+	{
+		public static readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(VideoPlayerWithLoadingIndicatorView), null);
+		public static readonly BindableProperty ActivityIndicatorColorProperty = BindableProperty.Create(nameof(ActivityIndicatorColor), typeof(Color), typeof(VideoPlayerWithLoadingIndicatorView), null);
+		public static readonly BindableProperty IsActivityIndicatorVisibleProperty = BindableProperty.Create(nameof(IsActivityIndicatorVisible), typeof(bool), typeof(VideoPlayerWithLoadingIndicatorView), true);
+		public static readonly BindableProperty IsActivityIndicatorRunningProperty = BindableProperty.Create(nameof(IsActivityIndicatorRunning), typeof(bool), typeof(VideoPlayerWithLoadingIndicatorView), true);
+
+		readonly VideoPlayerView _videoPlayerView;
+		readonly ActivityIndicator _activityIndicator = new();
+
+		public VideoPlayerWithLoadingIndicatorView(string? uri)
+		{
+			_videoPlayerView = new VideoPlayerView(uri);
+			Url = uri;
+
+			Padding = 0;
+
+			RowDefinitions = Rows.Define((Row.Video, Star));
+
+			Children.Add(_activityIndicator
+							.Row(Row.Video)
+							.Bind(ActivityIndicator.ColorProperty, nameof(ActivityIndicatorColor), source: this)
+							.Bind(ActivityIndicator.IsVisibleProperty, nameof(IsActivityIndicatorVisible), source: this)
+							.Bind(ActivityIndicator.IsRunningProperty, nameof(IsActivityIndicatorRunning), source: this));
+
+			Children.Add(_videoPlayerView
+							.Row(Row.Video)
+							.Bind(VideoPlayerView.UrlProperty, nameof(Url), source: this));
+		}
+
+		enum Row { Video }
+
+		public Color? ActivityIndicatorColor
+		{
+			get => (Color?)GetValue(ActivityIndicatorColorProperty);
+			set => SetValue(ActivityIndicatorColorProperty, value);
+		}
+
+		public bool IsActivityIndicatorVisible
+		{
+			get => (bool)GetValue(IsActivityIndicatorVisibleProperty);
+			set => SetValue(IsActivityIndicatorVisibleProperty, value);
+		}
+
+		public bool IsActivityIndicatorRunning
+		{
+			get => (bool)GetValue(IsActivityIndicatorRunningProperty);
+			set => SetValue(IsActivityIndicatorRunningProperty, value);
+		}
+
+		public string? Url
+		{
+			get => (string?)GetValue(UrlProperty);
+			set => SetValue(UrlProperty, value);
+		}
+	}
+}
+

--- a/GitTrends/Views/Base/VideoPlayerWithLoadingIndicatorView.cs
+++ b/GitTrends/Views/Base/VideoPlayerWithLoadingIndicatorView.cs
@@ -13,7 +13,7 @@ namespace GitTrends
 		public static readonly BindableProperty IsActivityIndicatorRunningProperty = BindableProperty.Create(nameof(IsActivityIndicatorRunning), typeof(bool), typeof(VideoPlayerWithLoadingIndicatorView), true);
 
 		readonly VideoPlayerView _videoPlayerView;
-		readonly ActivityIndicator _activityIndicator = new();
+		readonly ActivityIndicator _activityIndicator = new ActivityIndicator().Margin(10);
 
 		public VideoPlayerWithLoadingIndicatorView(string? uri)
 		{

--- a/GitTrends/Views/Settings/EnableOrganizationsCarouselTemplateSelector.cs
+++ b/GitTrends/Views/Settings/EnableOrganizationsCarouselTemplateSelector.cs
@@ -22,7 +22,7 @@ namespace GitTrends
 				Children =
 				{
 					includeOrganizationsModel.Url is not null
-						? new VideoPlayerView(includeOrganizationsModel.Url).Margin(24, 12)
+						? new VideoPlayerWithLoadingIndicatorView(includeOrganizationsModel.Url).Margin(24, 12)
 							.Row(EnableOrganizationsGrid.Row.Image)
 						: new Image { Source = includeOrganizationsModel.ImageSource, Aspect = Aspect.AspectFit }.Margin(24, 12)
 							.Row(EnableOrganizationsGrid.Row.Image),


### PR DESCRIPTION
To Do
- [x] Android - ActivityIndicator is visible behind VideoPlayerView
  - Fixed by adding a 10-point `Margin` to `ActivityIndicator`

![Screenshot_1658164851](https://user-images.githubusercontent.com/13558917/179567595-db0d73e4-a4a7-4541-820b-1915d6992f28.png)
