### PR TITLE
Ensure `Repository` Only Contains 14 Days of Views + Clones Data

### DIFF
--- a/GitTrends.Mobile.Common/Constants/DemoDataConstants.cs
+++ b/GitTrends.Mobile.Common/Constants/DemoDataConstants.cs
@@ -15,7 +15,7 @@ namespace GitTrends.Mobile.Common
 
 		static readonly Random _random = new Random((int)DateTime.Now.Ticks);
 
-		public static int GetRandomNumber() => _random.Next(0, MaximumRandomNumber);
+		public static int GetRandomNumber(int minimum = 0) => _random.Next(minimum, MaximumRandomNumber);
 
 		public static string GetRandomText(int? length = null)
 		{

--- a/GitTrends.Shared/Models/Repository.cs
+++ b/GitTrends.Shared/Models/Repository.cs
@@ -132,19 +132,21 @@ namespace GitTrends.Shared
 			var dailyViewsList = new List<DailyViewsModel>(dailyViews);
 
 			var day = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(13));
-			var maximumDay = DateTimeOffset.UtcNow;
+			var maximumAllowedDay = DateTimeOffset.UtcNow;
 
 			var daysList = dailyViews.Select(x => x.Day.Day).ToList();
 
-			while (day.Day != maximumDay.AddDays(1).Day)
+			while (day.Day != maximumAllowedDay.AddDays(1).Day)
 			{
 				if (!daysList.Contains(day.Day))
-					dailyViewsList.Add(new DailyViewsModel(RemoveHourMinuteSecond(day), 0, 0));
+					dailyViewsList.Add(new DailyViewsModel(day.RemoveHourMinuteSecond(), 0, 0));
 
 				day = day.AddDays(1);
 			}
 
-			return dailyViewsList;
+			return dailyViewsList.Count > 14
+					? dailyViewsList.Skip(dailyViewsList.Count - 14).ToList()
+					: dailyViewsList;
 		}
 
 		static IReadOnlyList<DailyClonesModel> AddMissingDates(in IEnumerable<DailyClonesModel> dailyClones)
@@ -152,22 +154,21 @@ namespace GitTrends.Shared
 			var dailyClonesList = new List<DailyClonesModel>(dailyClones);
 
 			var day = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(13));
-			var maximumDay = DateTimeOffset.UtcNow;
+			var maximumAllowedDay = DateTimeOffset.UtcNow;
 
 			var daysList = dailyClones.Select(x => x.Day.Day).ToList();
 
-			while (day.Day != maximumDay.AddDays(1).Day)
+			while (day.Day != maximumAllowedDay.AddDays(1).Day)
 			{
 				if (!daysList.Contains(day.Day))
-					dailyClonesList.Add(new DailyClonesModel(RemoveHourMinuteSecond(day), 0, 0));
+					dailyClonesList.Add(new DailyClonesModel(day.RemoveHourMinuteSecond(), 0, 0));
 
 				day = day.AddDays(1);
 			}
 
-			return dailyClonesList;
+			return dailyClonesList.Count > 14
+					? dailyClonesList.Skip(dailyClonesList.Count - 14).ToList()
+					: dailyClonesList;
 		}
-
-
-		static DateTimeOffset RemoveHourMinuteSecond(in DateTimeOffset date) => new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.Zero);
 	}
 }

--- a/GitTrends.Shared/Services/DateTimeService.cs
+++ b/GitTrends.Shared/Services/DateTimeService.cs
@@ -53,5 +53,7 @@ namespace GitTrends.Shared
 
 			return incompleteStarredAtList;
 		}
+
+		public static DateTimeOffset RemoveHourMinuteSecond(this DateTimeOffset date) => new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.Zero);
 	}
 }

--- a/GitTrends.UnitTests/Tests/Base/BaseTest.cs
+++ b/GitTrends.UnitTests/Tests/Base/BaseTest.cs
@@ -99,7 +99,7 @@ namespace GitTrends.UnitTests
 				dailyClonesList.Add(new DailyClonesModel(downloadedAt.Subtract(TimeSpan.FromDays(i)), count, uniqeCount));
 			}
 
-			var starredAt = DemoDataConstants.GenerateStarredAtDates(DemoDataConstants.GetRandomNumber()).ToList();
+			var starredAt = DemoDataConstants.GenerateStarredAtDates(DemoDataConstants.GetRandomNumber(1)).ToList();
 
 			return new Repository($"Repository " + DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomNumber(),
 														DemoUserConstants.Alias, gitTrendsAvatarUrl,

--- a/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
@@ -453,10 +453,10 @@ namespace GitTrends.UnitTests
 
 			Assert.AreEqual(repositoryDatabaseCount_Initial, repositoryDatabaseCount_Final);
 
-			Assert.Greater(expiredRepository_Initial.DailyClonesList.Sum(x => x.TotalClones), 1);
-			Assert.Greater(expiredRepository_Initial.DailyClonesList.Sum(x => x.TotalUniqueClones), 1);
-			Assert.Greater(expiredRepository_Initial.DailyViewsList.Sum(x => x.TotalViews), 1);
-			Assert.Greater(expiredRepository_Initial.DailyViewsList.Sum(x => x.TotalUniqueViews), 1);
+			Assert.AreEqual(0, expiredRepository_Initial.DailyClonesList.Sum(x => x.TotalClones));
+			Assert.AreEqual(0, expiredRepository_Initial.DailyClonesList.Sum(x => x.TotalUniqueClones));
+			Assert.AreEqual(0, expiredRepository_Initial.DailyViewsList.Sum(x => x.TotalViews));
+			Assert.AreEqual(0, expiredRepository_Initial.DailyViewsList.Sum(x => x.TotalUniqueViews));
 
 			Assert.IsNull(expiredRepository_Final.DailyClonesList);
 			Assert.IsNull(expiredRepository_Final.DailyViewsList);

--- a/GitTrends.UnitTests/Tests/Services/DateTimeServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/DateTimeServiceTests.cs
@@ -180,5 +180,25 @@ namespace GitTrends.UnitTests
 			Assert.AreEqual(expectedDate.Month, minimumDailyClonesModel.Month);
 			Assert.AreEqual(expectedDate.Day, minimumDailyClonesModel.Day);
 		}
+
+		[Test]
+		public void EnsureHourMinutesSecondsRemoved()
+		{
+			// Arrange
+			DateTimeOffset dateTimeOffset_Initial, dateTimeOffset_Final;
+			dateTimeOffset_Initial = DateTimeOffset.UtcNow;
+
+			// Act
+			dateTimeOffset_Final = dateTimeOffset_Initial.RemoveHourMinuteSecond();
+
+			// Asset
+			Assert.AreEqual(dateTimeOffset_Initial.Year, dateTimeOffset_Final.Year);
+			Assert.AreEqual(dateTimeOffset_Initial.Month, dateTimeOffset_Final.Month);
+			Assert.AreEqual(dateTimeOffset_Initial.Day, dateTimeOffset_Final.Day);
+			Assert.AreEqual(0, dateTimeOffset_Final.Hour);
+			Assert.AreEqual(0, dateTimeOffset_Final.Minute);
+			Assert.AreEqual(0, dateTimeOffset_Final.Second);
+			Assert.AreEqual(0, dateTimeOffset_Final.Millisecond);
+		}
 	}
 }

--- a/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
@@ -72,18 +72,30 @@ namespace GitTrends.UnitTests
 
 			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarCount, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
 
-			for (int i = 0; i < dailyViewsList_Final.Count; i++)
+			foreach (var dailyViewsModel_Final in dailyViewsList_Final)
 			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].LocalDay, dailyViewsList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalViews, dailyViewsList_Final[i].TotalViews);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
+				var dailyViewsModel_SavedToDatabase = repository_RepositorySavedToDatabaseResult
+														.DailyViewsList?.FirstOrDefault(x => x.Day == dailyViewsModel_Final.Day);
+
+				if (dailyViewsModel_SavedToDatabase is null)
+					continue;
+
+				Assert.AreEqual(dailyViewsModel_SavedToDatabase.LocalDay, dailyViewsModel_Final.LocalDay);
+				Assert.AreEqual(dailyViewsModel_SavedToDatabase.TotalViews, dailyViewsModel_Final.TotalViews);
+				Assert.AreEqual(dailyViewsModel_SavedToDatabase.TotalUniqueViews, dailyViewsModel_Final.TotalUniqueViews);
 			}
 
-			for (int i = 0; i < dailyClonesList_Final.Count; i++)
+			foreach (var dailyClonesModel_Final in dailyClonesList_Final)
 			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].LocalDay, dailyClonesList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalClones, dailyClonesList_Final[i].TotalClones);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
+				var dailyClonesModel_SavedToDatabase = repository_RepositorySavedToDatabaseResult
+														.DailyClonesList?.FirstOrDefault(x => x.Day == dailyClonesModel_Final.Day);
+
+				if (dailyClonesModel_SavedToDatabase is null)
+					continue;
+
+				Assert.AreEqual(dailyClonesModel_SavedToDatabase.LocalDay, dailyClonesModel_Final.LocalDay);
+				Assert.AreEqual(dailyClonesModel_SavedToDatabase.TotalClones, dailyClonesModel_Final.TotalClones);
+				Assert.AreEqual(dailyClonesModel_SavedToDatabase.TotalUniqueClones, dailyClonesModel_Final.TotalUniqueClones);
 			}
 
 			void HandleRepositorySavedToDatabase(object? sender, Repository e)
@@ -143,18 +155,30 @@ namespace GitTrends.UnitTests
 
 			Assert.AreEqual(repository_RepositorySavedToDatabaseResult.StarredAt?.Count, dailyStarsList_Final.Select(x => x.TotalStars).Distinct().Count());
 
-			for (int i = 0; i < dailyViewsList_Final.Count; i++)
+			foreach(var dailyViewsModel_Final in dailyViewsList_Final)
 			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].LocalDay, dailyViewsList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalViews, dailyViewsList_Final[i].TotalViews);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyViewsList?[i].TotalUniqueViews, dailyViewsList_Final[i].TotalUniqueViews);
+				var dailyViewsModel_SavedToDatabase = repository_RepositorySavedToDatabaseResult
+														.DailyViewsList?.FirstOrDefault(x => x.Day == dailyViewsModel_Final.Day);
+
+				if (dailyViewsModel_SavedToDatabase is null)
+					continue;
+
+				Assert.AreEqual(dailyViewsModel_SavedToDatabase.LocalDay, dailyViewsModel_Final.LocalDay);
+				Assert.AreEqual(dailyViewsModel_SavedToDatabase.TotalViews, dailyViewsModel_Final.TotalViews);
+				Assert.AreEqual(dailyViewsModel_SavedToDatabase.TotalUniqueViews, dailyViewsModel_Final.TotalUniqueViews);
 			}
 
-			for (int i = 0; i < dailyClonesList_Final.Count; i++)
+			foreach (var dailyClonesModel_Final in dailyClonesList_Final)
 			{
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].LocalDay, dailyClonesList_Final[i].LocalDay);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalClones, dailyClonesList_Final[i].TotalClones);
-				Assert.AreEqual(repository_RepositorySavedToDatabaseResult.DailyClonesList?[i].TotalUniqueClones, dailyClonesList_Final[i].TotalUniqueClones);
+				var dailyClonesModel_SavedToDatabase = repository_RepositorySavedToDatabaseResult
+														.DailyClonesList?.FirstOrDefault(x => x.Day == dailyClonesModel_Final.Day);
+
+				if (dailyClonesModel_SavedToDatabase is null)
+					continue;
+
+				Assert.AreEqual(dailyClonesModel_SavedToDatabase.LocalDay, dailyClonesModel_Final.LocalDay);
+				Assert.AreEqual(dailyClonesModel_SavedToDatabase.TotalClones, dailyClonesModel_Final.TotalClones);
+				Assert.AreEqual(dailyClonesModel_SavedToDatabase.TotalUniqueClones, dailyClonesModel_Final.TotalUniqueClones);
 			}
 
 			void HandleRepositorySavedToDatabase(object? sender, Repository e)


### PR DESCRIPTION
This PR fixes a bug where `Repository.AddMissingDays()` may result in a `Repository` containing more than 14 Days, despite the GitHub Traffic API only providing only 14 Days of Views + Clones data.