### PR TITLE
Remove SQLite NuGet Package from `GitTrends.UnitTests.csproj`

### DIFF
--- a/GitTrends.UnitTests/GitTrends.UnitTests.csproj
+++ b/GitTrends.UnitTests/GitTrends.UnitTests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="GitHubApiStatus.Extensions" Version="2.0.2" />


### PR DESCRIPTION
Removing `sqlite-net-pcl` from `GitTrends.UnitTests.csproj` upon the recommendation of [snitch](https://github.com/spectresystems/snitch)