### PR TITLE
Support Archived Repositories

### DIFF
--- a/GitTrends.Shared/Constants/AzureConstants.cs
+++ b/GitTrends.Shared/Constants/AzureConstants.cs
@@ -2,10 +2,13 @@
 {
 	public static class AzureConstants
 	{
-		public const string GetTestTokenApiKey = "B8qQh1B1-MfnWrvwhe3z1DxrL1c2cm6ZMV45ot2yYKlyAzFut3wSQQ==";
-		public const string GetAppCenterApiKeysKey = "xuyE4DFW1d56bp_hDVKqb_CeDWocolmUTeMsfxkcDS73AzFuEUiAaQ==";
-		public const string GetSyncFusionInformationApiKey = "WYiUp-Ewo5nVs5RF47XkQCamkFgl_9cSCXiUspGC_eMyAzFuFiCdQQ==";
-		public const string GetNotificationHubInformationApiKey = "SeCakN5St3mtAVKjPAXgb3R4sFnhDshJAB5cN0Np1XEcAzFu3-CpTA==";
-		public const string AzureFunctionsApiUrl = "https://gittrends-functions.azurewebsites.net/api";
+#if AppStore
+#error Missing API Keys
+#endif
+		public const string GetTestTokenApiKey = "";
+		public const string GetAppCenterApiKeysKey = "";
+		public const string GetSyncFusionInformationApiKey = "";
+		public const string GetNotificationHubInformationApiKey = "";
+		public const string AzureFunctionsApiUrl = "https://gittrendsfunctions.azurewebsites.net/api";
 	}
 }

--- a/GitTrends.Shared/Constants/AzureConstants.cs
+++ b/GitTrends.Shared/Constants/AzureConstants.cs
@@ -2,13 +2,10 @@
 {
 	public static class AzureConstants
 	{
-#if AppStore
-#error Missing API Keys
-#endif
-		public const string GetTestTokenApiKey = "";
-		public const string GetAppCenterApiKeysKey = "";
-		public const string GetSyncFusionInformationApiKey = "";
-		public const string GetNotificationHubInformationApiKey = "";
-		public const string AzureFunctionsApiUrl = "https://gittrendsfunctions.azurewebsites.net/api";
+		public const string GetTestTokenApiKey = "B8qQh1B1-MfnWrvwhe3z1DxrL1c2cm6ZMV45ot2yYKlyAzFut3wSQQ==";
+		public const string GetAppCenterApiKeysKey = "xuyE4DFW1d56bp_hDVKqb_CeDWocolmUTeMsfxkcDS73AzFuEUiAaQ==";
+		public const string GetSyncFusionInformationApiKey = "WYiUp-Ewo5nVs5RF47XkQCamkFgl_9cSCXiUspGC_eMyAzFuFiCdQQ==";
+		public const string GetNotificationHubInformationApiKey = "SeCakN5St3mtAVKjPAXgb3R4sFnhDshJAB5cN0Np1XEcAzFu3-CpTA==";
+		public const string AzureFunctionsApiUrl = "https://gittrends-functions.azurewebsites.net/api";
 	}
 }

--- a/GitTrends.Shared/Interfaces/IGitHubGraphQLAPI.cs
+++ b/GitTrends.Shared/Interfaces/IGitHubGraphQLAPI.cs
@@ -54,7 +54,7 @@ namespace GitTrends.Shared
 	public record RepositoryQueryContent : GraphQLRequest
 	{
 		public RepositoryQueryContent(string repositoryOwner, string repositoryName)
-			: base("query { repository(owner:\"" + repositoryOwner + "\" name:\"" + repositoryName + "\"){ viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }}}")
+			: base("query { repository(owner:\"" + repositoryOwner + "\" name:\"" + repositoryName + "\"){ isArchived, viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }}}")
 		{
 
 		}
@@ -63,7 +63,7 @@ namespace GitTrends.Shared
 	public record UserRepositoryConnectionQueryContent : GraphQLRequest
 	{
 		public UserRepositoryConnectionQueryContent(string repositoryOwner, string endCursorString, int numberOfRepositoriesPerRequest = 100)
-			: base("query{ user(login: \"" + repositoryOwner + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }, stargazers { totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
+			: base("query{ user(login: \"" + repositoryOwner + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { isArchived, viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }, stargazers { totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
 		{
 
 		}
@@ -72,7 +72,7 @@ namespace GitTrends.Shared
 	public record OrganizationRepositoryConnectionQueryContent : GraphQLRequest
 	{
 		public OrganizationRepositoryConnectionQueryContent(string organization, string endCursorString, int numberOfRepositoriesPerRequest = 100)
-			: base("query{ organization(login: \"" + organization + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }, stargazers { totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
+			: base("query{ organization(login: \"" + organization + "\") {repositories(first:" + numberOfRepositoriesPerRequest + endCursorString + ") { nodes { isArchived, viewerPermission, name, description, forkCount, url, owner { avatarUrl, login }, isFork, issues(states:OPEN) { totalCount }, watchers{ totalCount }, stargazers { totalCount } }, pageInfo { endCursor, hasNextPage, hasPreviousPage, startCursor } } } }")
 		{
 
 		}

--- a/GitTrends.Shared/Models/DTOs/RepositoryResponse.cs
+++ b/GitTrends.Shared/Models/DTOs/RepositoryResponse.cs
@@ -12,7 +12,8 @@ namespace GitTrends.Shared
 											bool IsFork,
 											IssuesConnection Issues,
 											Watchers Watchers,
-											string ViewerPermission)
+											string ViewerPermission,
+											bool IsArchived)
 	{
 		public RepositoryPermission Permission => (RepositoryPermission)Enum.Parse(typeof(RepositoryPermission), ViewerPermission);
 	}

--- a/GitTrends.Shared/Models/GetRepositoryResponse.cs
+++ b/GitTrends.Shared/Models/GetRepositoryResponse.cs
@@ -11,6 +11,8 @@ namespace GitTrends.Shared
 										string description,
 										long open_issues_count,
 										long stargazers_count,
+										bool archived,
+										Permissions permissions,
 										Owner_GetRepositoryResponse owner)
 		{
 			Name = name;
@@ -23,8 +25,19 @@ namespace GitTrends.Shared
 			WatchersCount = subscribers_count;
 			OwnerAvatarUrl = owner.AvatarUrl;
 			IssuesCount = open_issues_count;
+			IsArchived = archived;
 
 			DataDownloadedAt = DateTimeOffset.UtcNow;
+
+			Permission = permissions switch
+			{
+				{ Admin: true } => RepositoryPermission.ADMIN,
+				{ Maintain: true } => RepositoryPermission.MAINTAIN,
+				{ Push: true } => RepositoryPermission.WRITE,
+				{ Triage: true } => RepositoryPermission.TRIAGE,
+				{ Pull: true } => RepositoryPermission.READ,
+				_ => RepositoryPermission.UNKNOWN
+			};
 		}
 
 		public DateTimeOffset DataDownloadedAt { get; }
@@ -49,6 +62,8 @@ namespace GitTrends.Shared
 
 		public string Url { get; }
 
+		public bool IsArchived { get; }
+
 		public long? TotalViews { get; }
 
 		public long? TotalUniqueViews { get; }
@@ -58,7 +73,11 @@ namespace GitTrends.Shared
 		public long? TotalUniqueClones { get; }
 
 		public bool? IsFavorite { get; }
+
+		public RepositoryPermission Permission { get; }
 	}
+
+	public record Permissions(bool Admin, bool Maintain, bool Push, bool Triage, bool Pull);
 
 	public record Owner_GetRepositoryResponse : RepositoryOwner
 	{

--- a/GitTrends.Shared/Models/Interfaces/IRepository.cs
+++ b/GitTrends.Shared/Models/Interfaces/IRepository.cs
@@ -19,5 +19,7 @@ namespace GitTrends.Shared
 		long? TotalClones { get; }
 		long? TotalUniqueClones { get; }
 		bool? IsFavorite { get; }
+		bool IsArchived { get; }
+		RepositoryPermission Permission { get; }
 	}
 }

--- a/GitTrends.Shared/Models/Repository.cs
+++ b/GitTrends.Shared/Models/Repository.cs
@@ -23,6 +23,7 @@ namespace GitTrends.Shared
 							bool isFork,
 							DateTimeOffset dataDownloadedAt,
 							RepositoryPermission permission,
+							bool isArchived,
 							bool? isFavorite = null,
 							IEnumerable<DailyViewsModel>? views = null,
 							IEnumerable<DailyClonesModel>? clones = null,
@@ -42,6 +43,7 @@ namespace GitTrends.Shared
 			IsFork = isFork;
 			Url = url;
 			Permission = permission;
+			IsArchived = isArchived;
 			StarredAt = starredAt?.ToList();
 			DailyViewsList = views?.ToList();
 			DailyClonesList = clones?.ToList();
@@ -63,6 +65,7 @@ namespace GitTrends.Shared
 		public bool IsFork { get; init; }
 		public string Url { get; init; }
 		public RepositoryPermission Permission { get; init; }
+		public bool IsArchived { get; init; }
 
 		public bool? IsFavorite { get; init; }
 

--- a/GitTrends.Shared/Models/RepositoryConnection.cs
+++ b/GitTrends.Shared/Models/RepositoryConnection.cs
@@ -20,7 +20,7 @@ namespace GitTrends.Shared
 		public PageInfo PageInfo { get; }
 	}
 
-	public record RepositoryConnectionNode(string ViewerPermission, string Name, string Description, long ForkCount, Uri Url, RepositoryOwner Owner, bool IsFork, IssuesConnection Issues, Watchers Watchers, StarGazersConnection Stargazers)
+	public record RepositoryConnectionNode(bool IsArchived, string ViewerPermission, string Name, string Description, long ForkCount, Uri Url, RepositoryOwner Owner, bool IsFork, IssuesConnection Issues, Watchers Watchers, StarGazersConnection Stargazers)
 	{
 		public DateTimeOffset DataDownloadedAt { get; } = DateTimeOffset.UtcNow;
 

--- a/GitTrends.Shared/Services/RepositoryService.cs
+++ b/GitTrends.Shared/Services/RepositoryService.cs
@@ -6,11 +6,11 @@ namespace GitTrends.Shared
 {
 	public static class RepositoryService
 	{
-		public static IEnumerable<Repository> RemoveForksAndDuplicates(this IEnumerable<Repository> repositoriesList, Func<Repository, bool>? duplicateRepositoryPriorityFilter = null)
+		public static IEnumerable<Repository> RemoveForksDuplicatesAndArchives(this IEnumerable<Repository> repositoriesList, Func<Repository, bool>? duplicateRepositoryPriorityFilter = null)
 		{
 			duplicateRepositoryPriorityFilter ??= _ => true;
 
-			return repositoriesList.Where(x => !x.IsFork).OrderByDescending(x => x.DataDownloadedAt).GroupBy(x => x.Name).Select(x => x.FirstOrDefault(duplicateRepositoryPriorityFilter) ?? x.First());
+			return repositoriesList.Where(x => !x.IsFork && !x.IsArchived).OrderByDescending(x => x.DataDownloadedAt).GroupBy(x => x.Name).Select(x => x.FirstOrDefault(duplicateRepositoryPriorityFilter) ?? x.First());
 		}
 	}
 }

--- a/GitTrends.UnitTests/Tests/Base/BaseTest.cs
+++ b/GitTrends.UnitTests/Tests/Base/BaseTest.cs
@@ -104,7 +104,7 @@ namespace GitTrends.UnitTests
 			return new Repository($"Repository " + DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomNumber(),
 														DemoUserConstants.Alias, gitTrendsAvatarUrl,
 														DemoDataConstants.GetRandomNumber(), DemoDataConstants.GetRandomNumber(), starredAt.Count,
-														gitTrendsAvatarUrl, false, downloadedAt, RepositoryPermission.ADMIN, false, dailyViewsList, dailyClonesList, starredAt);
+														gitTrendsAvatarUrl, false, downloadedAt, RepositoryPermission.ADMIN, false, false, dailyViewsList, dailyClonesList, starredAt);
 		}
 	}
 }

--- a/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/BackgroundFetchServiceTests.cs
@@ -36,7 +36,7 @@ namespace GitTrends.UnitTests
 			Repository repository_Initial, repository_Final, repository_Database;
 
 			repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var scheduleRetryRepositoriesViewsClonesStarsCompletedTCS = new TaskCompletionSource<Repository>();
 			BackgroundFetchService.ScheduleRetryRepositoriesViewsClonesStarsCompleted += HandleScheduleRetryRepositoriesViewsClonesStarsCompleted;
@@ -132,7 +132,7 @@ namespace GitTrends.UnitTests
 			await AuthenticateUser(gitHubUserService, gitHubGraphQLApiService).ConfigureAwait(false);
 
 			repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			//Act
 			wasScheduledSuccessfully_First = backgroundFetchService.TryScheduleRetryRepositoriesStars(repository_Initial);
@@ -285,7 +285,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSitesList_Initial, mobileReferringSitesList_Final;
 
 			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var mobileReferringSiteRetrievedTCS = new TaskCompletionSource<MobileReferringSiteModel>();
 			var scheduleRetryGetReferringSiteCompletedTCS = new TaskCompletionSource<Repository>();
@@ -605,7 +605,7 @@ namespace GitTrends.UnitTests
 
 			return new Repository($"Repository " + DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomNumber(),
 														DemoUserConstants.Alias, GitHubConstants.GitTrendsAvatarUrl, DemoDataConstants.GetRandomNumber(), DemoDataConstants.GetRandomNumber(), starredAtList.Count,
-														repositoryUrl, false, downloadedAt, RepositoryPermission.ADMIN, true, dailyViewsList, dailyClonesList, starredAtList);
+														repositoryUrl, false, downloadedAt, RepositoryPermission.ADMIN, false, true, dailyViewsList, dailyClonesList, starredAtList);
 		}
 
 		static MobileReferringSiteModel CreateMobileReferringSite(DateTimeOffset downloadedAt, string referrer)

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiRepositoriesServiceTests.cs
@@ -46,14 +46,14 @@ namespace GitTrends.UnitTests
 				repositories_NoViewsClonesStarsData.Add(repository);
 			}
 
-			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksAndDuplicates().ToList();
+			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksDuplicatesAndArchives().ToList();
 
 			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories_NoStarsData.Add(repository);
 			}
 
-			repositories_Filtered = repositories_NoStarsData.RemoveForksAndDuplicates().ToList();
+			repositories_Filtered = repositories_NoStarsData.RemoveForksDuplicatesAndArchives().ToList();
 
 			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(repositories_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
@@ -210,7 +210,7 @@ namespace GitTrends.UnitTests
 				repositories_NoViewsClonesStarsData.Add(repository);
 			}
 
-			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksAndDuplicates().ToList();
+			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksDuplicatesAndArchives().ToList();
 
 			gitHubUserService.InvalidateToken();
 
@@ -219,7 +219,7 @@ namespace GitTrends.UnitTests
 				repositories_NoStarsData.Add(repository);
 			};
 
-			repositories_NoStarsData_Filtered = repositories_NoStarsData.RemoveForksAndDuplicates().ToList();
+			repositories_NoStarsData_Filtered = repositories_NoStarsData.RemoveForksDuplicatesAndArchives().ToList();
 
 			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(repositories_NoStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
@@ -255,14 +255,14 @@ namespace GitTrends.UnitTests
 				repositories_NoViewsClonesStarsData.Add(repository);
 			}
 
-			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksAndDuplicates().ToList();
+			repositories_NoViewsClonesStarsData_Filtered = repositories_NoViewsClonesStarsData.RemoveForksDuplicatesAndArchives().ToList();
 
 			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithViewsAndClonesData(repositories_NoViewsClonesStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
 				repositories_NoStarsData.Add(repository);
 			};
 
-			repositories_NoStarsData_Filtered = repositories_NoStarsData.RemoveForksAndDuplicates().ToList();
+			repositories_NoStarsData_Filtered = repositories_NoStarsData.RemoveForksDuplicatesAndArchives().ToList();
 
 			await foreach (var repository in gitHubApiRepositoriesService.UpdateRepositoriesWithStarsData(repositories_NoStarsData_Filtered, CancellationToken.None).ConfigureAwait(false))
 			{
@@ -287,7 +287,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<ReferringSiteModel> referringSiteModels;
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
@@ -318,7 +318,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<ReferringSiteModel> referringSiteModels;
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
@@ -345,7 +345,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<ReferringSiteModel> referringSiteModels;
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubAuthenticationService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubAuthenticationService>();
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
@@ -375,7 +375,7 @@ namespace GitTrends.UnitTests
 		{
 			// Arrange
 			var repository = new Repository(string.Empty, string.Empty, 1, string.Empty,
-												string.Empty, 1, 2, 3, string.Empty, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												string.Empty, 1, 2, 3, string.Empty, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
@@ -392,7 +392,7 @@ namespace GitTrends.UnitTests
 			List<MobileReferringSiteModel> mobileReferringSiteModels = new();
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubGraphQLApiService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubGraphQLApiService>();
@@ -434,7 +434,7 @@ namespace GitTrends.UnitTests
 			List<MobileReferringSiteModel> mobileReferringSiteModels = new();
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();
 
@@ -472,7 +472,7 @@ namespace GitTrends.UnitTests
 			List<MobileReferringSiteModel> mobileReferringSiteModels = new();
 
 			var repository = new Repository(GitHubConstants.GitTrendsRepoName, GitHubConstants.GitTrendsRepoName, 1, GitHubConstants.GitTrendsRepoOwner,
-												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												GitHubConstants.GitTrendsAvatarUrl, 1, 2, 3, "https://github.com/brminnick/gittrends", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubAuthenticationService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubAuthenticationService>();
 			var gitHubApiRepositoriesService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiRepositoriesService>();

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests.cs
@@ -25,7 +25,7 @@ namespace GitTrends.UnitTests
 			var pullToRefreshFailedTCS = new TaskCompletionSource<PullToRefreshFailedEventArgs>();
 
 			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
-				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			ReferringSitesViewModel.PullToRefreshFailed += HandlePullToRefreshFailed;
 
@@ -89,7 +89,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
 			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
-				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var referringSitesViewModel = ServiceCollection.ServiceProvider.GetRequiredService<ReferringSitesViewModel>();

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_AbuseApiLimit.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_AbuseApiLimit.cs
@@ -26,7 +26,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
 			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
-				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var referringSitesViewModel = ServiceCollection.ServiceProvider.GetRequiredService<ReferringSitesViewModel>();

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_MaximumApiCallLimit.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_MaximumApiCallLimit.cs
@@ -27,7 +27,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
 			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
-				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var referringSitesViewModel = ServiceCollection.ServiceProvider.GetRequiredService<ReferringSitesViewModel>();

--- a/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_ServerError.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/ReferringSitesViewModel/ReferringSitesViewModelTests_ServerError.cs
@@ -26,7 +26,7 @@ namespace GitTrends.UnitTests
 			IReadOnlyList<MobileReferringSiteModel> mobileReferringSites_Initial, mobileReferringSites_DuringRefresh, mobileReferringSites_Final;
 
 			var mockGitTrendsRepository = new Repository(GitHubConstants.GitTrendsRepoName, "", 0, GitHubConstants.GitTrendsRepoOwner, AuthenticatedGitHubUserAvatarUrl, 0, 0, 0,
-				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+				$"https://github.com/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var referringSitesViewModel = ServiceCollection.ServiceProvider.GetRequiredService<ReferringSitesViewModel>();

--- a/GitTrends.UnitTests/Tests/ViewModels/RepositoryViewModel/RepositoryViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/RepositoryViewModel/RepositoryViewModelTests.cs
@@ -85,6 +85,9 @@ namespace GitTrends.UnitTests
 				Assert.IsNotNull(repository.TotalUniqueViews);
 				Assert.IsNotNull(repository.TotalViews);
 
+				Assert.IsFalse(repository.IsArchived);
+				Assert.IsFalse(repository.IsFork);
+
 				Assert.Less(beforePullToRefresh, repository.DataDownloadedAt);
 				Assert.Greater(afterPullToRefresh, repository.DataDownloadedAt);
 			}

--- a/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
+++ b/GitTrends.UnitTests/Tests/ViewModels/TrendsViewModelTests.cs
@@ -109,7 +109,7 @@ namespace GitTrends.UnitTests
 		public async Task FetchDataCommandTest_AuthenticatedUser_NoData()
 		{
 			//Arrange
-			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 			Repository repository_RepositorySavedToDatabaseResult;
 
 			TaskCompletionSource<Repository> repositorySavedToDatabaseTCS = new();
@@ -193,7 +193,7 @@ namespace GitTrends.UnitTests
 		{
 			//Arrange
 			bool wasTryScheduleRetryRepositoriesStarsSuccessful;
-			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();
@@ -281,7 +281,7 @@ namespace GitTrends.UnitTests
 		public async Task FetchDataCommandTest_AuthenticatedUser_TokenCancelled()
 		{
 			//Arrange
-			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var cancellationTokenSource = new CancellationTokenSource();
 
@@ -310,7 +310,7 @@ namespace GitTrends.UnitTests
 		{
 			//Arrange
 			bool wasTryScheduleRetryRepositoriesViewsClonesStarsSuccessful;
-			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+			Repository repository_Initial = new Repository(GitHubConstants.GitTrendsRepoName, string.Empty, 0, GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsAvatarUrl, 0, 0, 0, $"{GitHubConstants.GitHubBaseUrl}/{GitHubConstants.GitTrendsRepoOwner}/{GitHubConstants.GitTrendsRepoName}", false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var backgroundFetchService = ServiceCollection.ServiceProvider.GetRequiredService<BackgroundFetchService>();

--- a/GitTrends/Database/RepositoryDatabase.cs
+++ b/GitTrends/Database/RepositoryDatabase.cs
@@ -340,6 +340,8 @@ namespace GitTrends
 
 			public bool IsFork { get; init; }
 
+			public bool IsArchived { get; init; }
+
 			public long? TotalViews { get; init; }
 
 			public long? TotalUniqueViews { get; init; }
@@ -372,6 +374,7 @@ namespace GitTrends
 										repositoryDatabaseModel.IsFork,
 										repositoryDatabaseModel.DataDownloadedAt,
 										repositoryDatabaseModel.Permission,
+										repositoryDatabaseModel.IsArchived,
 										repositoryDatabaseModel.IsFavorite,
 										viewsList,
 										clonesList,

--- a/GitTrends/Services/BackgroundFetchService.cs
+++ b/GitTrends/Services/BackgroundFetchService.cs
@@ -391,7 +391,7 @@ namespace GitTrends
 						retrievedRepositoryList.Add(repository);
 				}
 
-				var retrievedRepositoryList_NoDuplicatesNoForks = retrievedRepositoryList.RemoveForksAndDuplicates(x => x.ContainsViewsClonesData);
+				var retrievedRepositoryList_NoDuplicatesNoForks = retrievedRepositoryList.RemoveForksDuplicatesAndArchives(x => x.ContainsViewsClonesData);
 
 				IReadOnlyList<Repository> repositoriesToUpdate = repositoriesFromDatabase.Where(x => _gitHubUserService.ShouldIncludeOrganizations || x.OwnerLogin == _gitHubUserService.Alias) // Only include organization repositories if `ShouldIncludeOrganizations` is true
 											.Where(x => x.DataDownloadedAt < DateTimeOffset.Now.Subtract(TimeSpan.FromHours(12))) // Cached repositories that haven't been updated in 12 hours 

--- a/GitTrends/Services/GitHubGraphQLApiService.cs
+++ b/GitTrends/Services/GitHubGraphQLApiService.cs
@@ -72,6 +72,7 @@ namespace GitTrends
 									repositoryResult.Repository.IsFork,
 									DateTimeOffset.UtcNow,
 									repositoryResult.Repository.Permission,
+									repositoryResult.Repository.IsArchived,
 									starredAt: starGazersResult.StarredAt.Select(x => x.StarredAt));
 		}
 
@@ -110,7 +111,7 @@ namespace GitTrends
 				{
 					var demoRepo = new Repository($"Repository " + DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomText(), DemoDataConstants.GetRandomNumber(),
 												DemoUserConstants.Alias, _gitHubUserService.AvatarUrl, DemoDataConstants.GetRandomNumber(), DemoDataConstants.GetRandomNumber(),
-												DemoDataConstants.GetRandomNumber(), _gitHubUserService.AvatarUrl, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN);
+												DemoDataConstants.GetRandomNumber(), _gitHubUserService.AvatarUrl, false, DateTimeOffset.UtcNow, RepositoryPermission.ADMIN, false);
 					yield return demoRepo;
 				}
 
@@ -177,7 +178,7 @@ namespace GitTrends
 					{
 						if (repository is not null)
 							repositoryList.Add(new Repository(repository.Name, repository.Description, repository.ForkCount, repository.Owner.Login, repository.Owner.AvatarUrl,
-														repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Stargazers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission));
+														repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Stargazers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission, repository.IsArchived));
 					}
 				}
 				while (repositoryConnection?.PageInfo?.HasNextPage is true);
@@ -222,7 +223,7 @@ namespace GitTrends
 				{
 					if (repository is not null)
 						yield return new Repository(repository.Name, repository.Description, repository.ForkCount, repository.Owner.Login, repository.Owner.AvatarUrl,
-													repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Stargazers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission);
+													repository.Issues.IssuesCount, repository.Watchers.TotalCount, repository.Stargazers.TotalCount, repository.Url.ToString(), repository.IsFork, repository.DataDownloadedAt, repository.Permission, repository.IsArchived);
 				}
 			}
 			while (repositoryConnection?.PageInfo?.HasNextPage is true);

--- a/GitTrends/Services/NotificationService.cs
+++ b/GitTrends/Services/NotificationService.cs
@@ -276,7 +276,7 @@ namespace GitTrends
 					//Create repository with only Name & Owner, because those are the only metrics that TrendsPage needs to fetch the chart data
 					var repository = new Repository(MostRecentTrendingRepositoryName, string.Empty, 0,
 													MostRecentTrendingRepositoryOwner, string.Empty,
-													0, 0, 0, string.Empty, false, default, RepositoryPermission.UNKNOWN);
+													0, 0, 0, string.Empty, false, default, RepositoryPermission.UNKNOWN, false);
 
 					await _deepLinkingService.NavigateToTrendsPage(repository).ConfigureAwait(false);
 				}

--- a/GitTrends/ViewModels/RepositoryViewModel.cs
+++ b/GitTrends/ViewModels/RepositoryViewModel.cs
@@ -404,7 +404,7 @@ namespace GitTrends
 			duplicateRepositoryPriorityFilter ??= _ => true;
 
 			var updatedRepositoryList = _repositoryList.Concat(repositories);
-			_repositoryList = updatedRepositoryList.RemoveForksAndDuplicates(duplicateRepositoryPriorityFilter).ToList();
+			_repositoryList = updatedRepositoryList.RemoveForksDuplicatesAndArchives(duplicateRepositoryPriorityFilter).ToList();
 
 			if (shouldUpdateVisibleRepositoryList)
 				UpdateVisibleRepositoryList(searchBarText, _mobileSortingService.CurrentOption, _mobileSortingService.IsReversed);
@@ -421,7 +421,7 @@ namespace GitTrends
 				updatedRepositoryList.Remove(repositoryToRemove);
 			}
 
-			_repositoryList = updatedRepositoryList.RemoveForksAndDuplicates(x => x.ContainsViewsClonesStarsData).ToList();
+			_repositoryList = updatedRepositoryList.RemoveForksDuplicatesAndArchives(x => x.ContainsViewsClonesStarsData).ToList();
 
 			if (shouldUpdateVisibleRepositoryList)
 				UpdateVisibleRepositoryList(searchBarText, _mobileSortingService.CurrentOption, _mobileSortingService.IsReversed);


### PR DESCRIPTION
[Archived repositories](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories) do not track Views + Clones data.

This Pull Request ensures archived repositories are removed, along with Forks.