### PR TITLE
Update VideoPlayerView

### DIFF
--- a/GitTrends.Android/Properties/AndroidManifest.xml
+++ b/GitTrends.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="56" android:versionName="2.5.2" package="com.minnick.gittrends" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="57" android:versionName="2.5.3" package="com.minnick.gittrends" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="33" />
 	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 	<application android:label="GitTrends" android:fullBackupContent="@xml/auto_backup_rules">

--- a/GitTrends.Shared/Models/StreamingUrl.cs
+++ b/GitTrends.Shared/Models/StreamingUrl.cs
@@ -5,8 +5,8 @@
 		public StreamingManifest(string manifestUrl)
 		{
 			ManifestUrl = manifestUrl;
-			HlsUrl = manifestUrl + "(format=m3u8-aapl)";
-			DashUrl = manifestUrl + "(format=mpd-time-csf)";
+			HlsUrl = manifestUrl + "(format=m3u8-cmaf)";
+			DashUrl = manifestUrl + "(format=mpd-time-cmaf)";
 		}
 
 		public string ManifestUrl { get; }

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
@@ -3,8 +3,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using GitHubApiStatus;
-using GitHubApiStatus.Extensions;
 using GitTrends.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -244,22 +242,19 @@ namespace GitTrends.UnitTests
 			//"Could not resolve to a Repository with the name 'zxcvbnmlkjhgfdsa1234567890/abc123321'."
 		}
 
-		[Test]
+		[Test, Ignore("Test Fails When GitHub API Rate Limit Exceeded")]
 		public async Task GetStarGazers_Unauthenticated()
 		{
 			//Arrange
 			StarGazers starGazers;
+			var httpClient = ServiceCollection.ServiceProvider.GetRequiredService<IHttpClientFactory>().CreateClient();
+			httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(new ProductHeaderValue(nameof(GitTrends))));
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubApiV3Service = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiV3Service>();
-			var gitHubApiStatusService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiStatusService>();
 
 			//Act
 			gitHubUserService.InvalidateToken();
-
-			var rateLimits = await gitHubApiStatusService.GetApiRateLimits().ConfigureAwait(false);
-			if (rateLimits.RestApi.RemainingRequestCount < 1000)
-				Assert.Ignore("Test Fails When GitHub API Rate Limit Exceeded");
 
 			starGazers = await gitHubApiV3Service.GetStarGazers(GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsRepoName, CancellationToken.None).ConfigureAwait(false);
 

--- a/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
+++ b/GitTrends.UnitTests/Tests/Services/GitHubApiV3ServiceTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using GitHubApiStatus;
+using GitHubApiStatus.Extensions;
 using GitTrends.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -242,19 +244,22 @@ namespace GitTrends.UnitTests
 			//"Could not resolve to a Repository with the name 'zxcvbnmlkjhgfdsa1234567890/abc123321'."
 		}
 
-		[Test, Ignore("Test Fails When GitHub API Rate Limit Exceeded")]
+		[Test]
 		public async Task GetStarGazers_Unauthenticated()
 		{
 			//Arrange
 			StarGazers starGazers;
-			var httpClient = ServiceCollection.ServiceProvider.GetRequiredService<IHttpClientFactory>().CreateClient();
-			httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(new ProductHeaderValue(nameof(GitTrends))));
 
 			var gitHubUserService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubUserService>();
 			var gitHubApiV3Service = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiV3Service>();
+			var gitHubApiStatusService = ServiceCollection.ServiceProvider.GetRequiredService<GitHubApiStatusService>();
 
 			//Act
 			gitHubUserService.InvalidateToken();
+
+			var rateLimits = await gitHubApiStatusService.GetApiRateLimits().ConfigureAwait(false);
+			if (rateLimits.RestApi.RemainingRequestCount < 1000)
+				Assert.Ignore("Test Fails When GitHub API Rate Limit Exceeded");
 
 			starGazers = await gitHubApiV3Service.GetStarGazers(GitHubConstants.GitTrendsRepoOwner, GitHubConstants.GitTrendsRepoName, CancellationToken.None).ConfigureAwait(false);
 

--- a/GitTrends.iOS/CustomRenderers/VideoPlayerViewCustomRenderer.cs
+++ b/GitTrends.iOS/CustomRenderers/VideoPlayerViewCustomRenderer.cs
@@ -35,7 +35,7 @@ namespace GitTrends.iOS
         {
             base.OnElementPropertyChanged(sender, e);
 
-            if (e.PropertyName is nameof(Element.Url)
+            if (e.PropertyName == VideoPlayerView.UrlProperty.PropertyName
                 && _avPlayerViewController.View is not null
                 && Element.Url is not null)
             {

--- a/GitTrends.iOS/Info.plist
+++ b/GitTrends.iOS/Info.plist
@@ -57,14 +57,14 @@
 		<string>processing</string>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.2</string>
+	<string>2.5.3</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.minnick.GitTrends.NotifyTrendingRepositories</string>
 		<string>com.minnick.GitTrends.CleanUpDatabase</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>56</string>
+	<string>57</string>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>


### PR DESCRIPTION
This PR also fixes a bug to only update VisibleRepositoryList on event handers when `RefreshState is RefreshState.Succeeded or RefreshState.Uninitialized`